### PR TITLE
Implement CassandraDB Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tests options:
 - `pct_cert_login`: percent of requests that are cert logins
 - `pct_pki_issue`: percent of requests that are pki issues
 - `pki_gen_lease`: when running PKI issue tests, set to true to generate leases for each cert
+- `pct_cassandradb_read`: percent of requests that are CassandraDB Dynamic Credential generations
 
 There is also a `numkvs` option: if any kvv1 or kvv2 requests are specified,
 then this many keys will be written during the setup phase.  The read operations
@@ -44,6 +45,32 @@ op          mean       95th%       99th        successRatio
 kvv1 read   817.22µs   1.674553ms  2.437689ms  100.00%
 kvv1 write  905.852µs  1.825512ms  2.59166ms   100.00%
 ```
+
+# Tests
+## CassandraDB
+
+This benchmark will test the dynamic generation of CassandraDB credentials. In order to use this test, configuration for the CassandraDB instance must be provided as a JSON file using the `cassandradb_config_json` flag. The primary required fields are the `username` and `password` for the user configured in CassandraDB for Vault to use, as well as the `hosts` field that defines the addresses to be use and the `protocol_version`. Below is an example configuration to communicate with a locally running test environment:
+
+```
+{
+    "hosts": "127.0.0.1",
+    "protocol_version": 4,
+    "username":"vault",
+    "password":"vault"
+}
+```
+
+Please refer to the CassandraDB Vault documentation for all available configuration options.
+
+A role configuration file can also be passed via the `cassandradb_role_config_json` flag. This allows more specific options to be specified if required by the CassandraDB environment setup. By default the following role `benchmark-role` is defined and used:
+```
+{
+	"default_ttl": "1h",
+	"max_ttl": "24h",
+	"creation_statements": "CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER; GRANT SELECT ON ALL KEYSPACES TO {{username}};"
+}
+```
+Any configuration passed will modify the `benchmark-role`.
 
 # Outputs
 

--- a/vegeta/target_secret_cassandra.go
+++ b/vegeta/target_secret_cassandra.go
@@ -1,0 +1,179 @@
+package vegeta
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/api"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+)
+
+type cassandratest struct {
+	pathPrefix string
+	header     http.Header
+	roleName   string
+}
+
+type CassandraDBConfig struct {
+	pluginName       string   `json:"-"`
+	Hosts            string   `json:"hosts"`
+	Port             int      `json:"port"`
+	ProtocolVersion  int      `json:"protocol_version"`
+	Username         string   `json:"username"`
+	Password         string   `json:"password"`
+	AllowedRoles     []string `json:"-"`
+	TLS              bool     `json:"tls"`
+	InsecureTLS      bool     `json:"insecure_tls"`
+	TLSServerName    string   `json:"tls_server_name"`
+	PEMBundle        string   `json:"pem_bundle"`
+	PEMJSON          string   `json:"pem_json"`
+	SkipVerification bool     `json:"skip_verification"`
+	ConnectTimeout   string   `json:"connect_timeout"`
+	LocalDatacenter  string   `json:"local_datacenter"`
+	SocketKeepAlive  string   `json:"socket_keep_alive"`
+	Consistency      string   `json:"consistency"`
+	UsernameTemplate string   `json:"username_template"`
+}
+
+type CassandraRoleConfig struct {
+	Name                 string `json:"-"`
+	DBName               string `json:"-"`
+	DefaultTTL           string `json:"default_ttl"`
+	MaxTTL               string `json:"max_ttl"`
+	CreationStatements   string `json:"creation_statements"`
+	RevocationStatements string `json:"revocation_statements"`
+	RollbackStatements   string `json:"rollback_statements"`
+}
+
+func (r *CassandraRoleConfig) FromJSON(path string) error {
+	// Set defaults
+	r.Name = "benchmark-role"
+	r.DBName = "cassandra-benchmark-database"
+	r.DefaultTTL = "1h"
+	r.MaxTTL = "24h"
+	r.CreationStatements = "CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER; GRANT SELECT ON ALL KEYSPACES TO {{username}};"
+
+	if path == "" {
+		return nil
+	}
+
+	// Then load JSON config
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CassandraDBConfig) FromJSON(path string) error {
+	// Set CassandraDB Plugin
+	c.pluginName = "cassandra-database-plugin"
+	c.AllowedRoles = []string{
+		"benchmark-role",
+	}
+
+	if path == "" {
+		return fmt.Errorf("no CassandraDB config passed but is required")
+	}
+
+	// Then load JSON config
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(c); err != nil {
+		return err
+	}
+
+	// Check for required fields
+	switch {
+	case c.Hosts == "":
+		return fmt.Errorf("no hosts passed but is required")
+	case c.Username == "":
+		return fmt.Errorf("no username passed but is required")
+	case c.Password == "":
+		return fmt.Errorf("no password passed but is required")
+	default:
+		return nil
+	}
+}
+
+func (c *cassandratest) read(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: "GET",
+		URL:    client.Address() + c.pathPrefix + "/creds/" + c.roleName,
+		Header: c.header,
+	}
+}
+
+func setupCassandra(client *api.Client, randomMounts bool, config *CassandraDBConfig, roleConfig *CassandraRoleConfig) (*cassandratest, error) {
+	cassandraPath, err := uuid.GenerateUUID()
+	if err != nil {
+		panic("can't create UUID")
+	}
+	if !randomMounts {
+		cassandraPath = "cassandra"
+	}
+
+	err = client.Sys().Mount(cassandraPath, &api.MountInput{
+		Type: "database",
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error mounting db: %v", err)
+	}
+
+	// Write DB config
+	_, err = client.Logical().Write(cassandraPath+"/config/cassandra-benchmark-database", map[string]interface{}{
+		"plugin_name":       config.pluginName,
+		"hosts":             config.Hosts,
+		"protocol_version":  config.ProtocolVersion,
+		"username":          config.Username,
+		"password":          config.Password,
+		"allowed_roles":     config.AllowedRoles,
+		"port":              config.Port,
+		"tls":               config.TLS,
+		"insecure_tls":      config.InsecureTLS,
+		"tls_server_name":   config.TLSServerName,
+		"pem_bundle":        config.PEMBundle,
+		"pem_json":          config.PEMJSON,
+		"skip_verification": config.SkipVerification,
+		"connect_timeout":   config.ConnectTimeout,
+		"local_datacenter":  config.LocalDatacenter,
+		"socket_keep_alive": config.SocketKeepAlive,
+		"consistency":       config.Consistency,
+		"username_template": config.UsernameTemplate,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error writing db config: %v", err)
+	}
+
+	// Create Role
+	_, err = client.Logical().Write(cassandraPath+"/roles/"+roleConfig.Name, map[string]interface{}{
+		"db_name":             roleConfig.DBName,
+		"creation_statements": roleConfig.CreationStatements,
+		"default_ttl":         roleConfig.DefaultTTL,
+		"max_ttl":             roleConfig.MaxTTL,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error writing db role: %v", err)
+	}
+
+	return &cassandratest{
+		pathPrefix: "/v1/" + cassandraPath,
+		header:     http.Header{"X-Vault-Token": []string{client.Token()}, "X-Vault-Namespace": []string{client.Headers().Get("X-Vault-Namespace")}},
+		roleName:   roleConfig.Name,
+	}, nil
+}

--- a/vegeta/targets.go
+++ b/vegeta/targets.go
@@ -31,7 +31,7 @@ func (tm TargetMulti) validate() error {
 		total += fraction.percent
 	}
 	if total != 100 {
-		return fmt.Errorf("total comes to %d, should be 100", total)
+		return fmt.Errorf("test percentage total comes to %d, should be 100", total)
 	}
 	return nil
 }
@@ -97,31 +97,34 @@ func (tm TargetMulti) DebugInfo(client *api.Client) {
 }
 
 type TestSpecification struct {
-	NumKVs               int
-	KVSize               int
-	RandomMounts         bool
-	TokenTTL             time.Duration
-	PctKvv1Read          int
-	PctKvv1Write         int
-	PctKvv2Read          int
-	PctKvv2Write         int
-	PctPkiIssue          int
-	PkiConfig            PkiTestConfig
-	PctApproleLogin      int
-	PctCertLogin         int
-	PctSshCaIssue        int
-	SshCaConfig          SshCaTestConfig
-	PctHAStatus          int
-	PctSealStatus        int
-	PctMetrics           int
-	PctTransitSign       int
-	TransitSignConfig    transitTestConfig
-	PctTransitVerify     int
-	TransitVerifyConfig  transitTestConfig
-	PctTransitEncrypt    int
-	TransitEncryptConfig transitTestConfig
-	PctTransitDecrypt    int
-	TransitDecryptConfig transitTestConfig
+	NumKVs                int
+	KVSize                int
+	RandomMounts          bool
+	TokenTTL              time.Duration
+	PctKvv1Read           int
+	PctKvv1Write          int
+	PctKvv2Read           int
+	PctKvv2Write          int
+	PctPkiIssue           int
+	PkiConfig             PkiTestConfig
+	PctApproleLogin       int
+	PctCertLogin          int
+	PctSshCaIssue         int
+	SshCaConfig           SshCaTestConfig
+	PctHAStatus           int
+	PctSealStatus         int
+	PctMetrics            int
+	PctTransitSign        int
+	TransitSignConfig     transitTestConfig
+	PctTransitVerify      int
+	TransitVerifyConfig   transitTestConfig
+	PctTransitEncrypt     int
+	TransitEncryptConfig  transitTestConfig
+	PctTransitDecrypt     int
+	TransitDecryptConfig  transitTestConfig
+	PctCassandraRead      int
+	CassandraDBConfig     CassandraDBConfig
+	CassandraDBRoleConfig CassandraRoleConfig
 }
 
 func BuildTargets(spec TestSpecification, client *api.Client, caPEM string, clientCAPem string) (*TargetMulti, error) {
@@ -300,6 +303,19 @@ func BuildTargets(spec TestSpecification, client *api.Client, caPEM string, clie
 			pathPrefix: transit.pathPrefix,
 			percent:    spec.PctTransitDecrypt,
 			target:     transit.write,
+		})
+	}
+	if spec.PctCassandraRead > 0 {
+		cassandra, err := setupCassandra(client, spec.RandomMounts, &spec.CassandraDBConfig, &spec.CassandraDBRoleConfig)
+		if err != nil {
+			return nil, err
+		}
+		tm.fractions = append(tm.fractions, targetFraction{
+			name:       "cassandra cred retrieval",
+			method:     "GET",
+			pathPrefix: cassandra.pathPrefix,
+			percent:    spec.PctCassandraRead,
+			target:     cassandra.read,
 		})
 	}
 


### PR DESCRIPTION
This PR implements the CassandraDB Benchmark. This benchmark stands up a randomly named (if not defined) CassandraDB Database Secrets engine mount in Vault and defines a `benchmark-role` role to test dynamic credential generation. Configuration can be passed via JSON config files as CLI flags. Example run scenario below:

```
./benchmark-vault -vault_addr=https://127.0.0.1:8200 -vault_token=root -ca_pem_file=$(pwd)/testing/certs/vault_rootCA.pem -pct_cassandradb_read=100 -cassandradb_config_json=$(pwd)/cassandradb_config.json -cassandradb_role_config_json=$(pwd)/cassandradb_role_config.json
https://127.0.0.1:8200
op                        count  rate       throughput  mean          95th%         99th%         successRatio
cassandra cred retrieval  137    13.685611  12.707332   753.872446ms  999.867979ms  1.075487603s  100.00%
```