### PR TITLE
Implement LDAP Auth benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ A role configuration file can also be passed via the `cassandradb_role_config_js
 ```
 Any configuration passed will modify the `benchmark-role`.
 
+## LDAP Auth
+
+This benchmark will test LDAP Authentication to Vault. In order to use this test, configuration for the target LDAP server(s) must be provided as a JSON file using the `ldap_config_json` flag. The primary required fields are `url` and `groupdn` depending on the LDAP environment setup and desired connection method. Below is an example configuration to communicate with a locally running LDAP test environment:
+
+```
+{
+	"url":"ldap://127.0.0.1",
+	"userdn":"ou=users,dc=hashicorp,dc=com",
+	"groupdn":"ou=groups,dc=hashicorp,dc=com",
+	"binddn":"cn=admin,dc=hashicorp,dc=com",
+	"bindpass":"admin",
+	"userattr":"uid",
+	"groupattr":"cn",
+	"groupfilter":"(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))"
+}
+```
+
+Please refer to the Vault LDAP Auth documentation for all available configuration options.
+
 # Outputs
 
 ## Reports

--- a/main.go
+++ b/main.go
@@ -55,6 +55,8 @@ func main() {
 		transitDecryptConfigJSON  = flag.String("transit_decrypt_config_json", "", "when specified, path to Transit decrypt benchmark configuration JSON file to use")
 		cassandraDBConfigJSON     = flag.String("cassandradb_config_json", "", "path to JSON file containing Vault CassandraDB configuration")
 		cassandraDBRoleConfigJSON = flag.String("cassandradb_role_config_json", "", "when specified, path to CassandraDB benchmark role configuration JSON file to use")
+		ldapConfigJSON            = flag.String("ldap_config_json", "", "path to JSON file containing Vault LDAP Auth configuration")
+		ldapTestUserCredsJSON     = flag.String("ldap_test_user_creds_json", "", "path to JSON file containing test user credentials for LDAP Auth benchmarking")
 	)
 
 	// test-related settings
@@ -78,6 +80,7 @@ func main() {
 	flag.IntVar(&spec.PctTransitEncrypt, "pct_transit_encrypt", 0, "percent of requests that are encrypt requests to transit")
 	flag.IntVar(&spec.PctTransitDecrypt, "pct_transit_decrypt", 0, "percent of requests that are decrypt requests to transit")
 	flag.IntVar(&spec.PctCassandraRead, "pct_cassandradb_read", 0, "percent of requests that are CassandraDB credential generations")
+	flag.IntVar(&spec.PctLDAPLogin, "pct_ldap_login", 0, "percent of requests that are LDAP logins")
 
 	// Config Options
 	flag.DurationVar(&spec.PkiConfig.SetupDelay, "pki_setup_delay", 50*time.Millisecond, "When running PKI tests, delay after creating mount before attempting issuer creation")
@@ -113,12 +116,26 @@ func main() {
 		log.Fatalf("unable to parse Transit decrypt config at %v: %v", *transitDecryptConfigJSON, err)
 	}
 
-	if err := spec.CassandraDBConfig.FromJSON(*cassandraDBConfigJSON); err != nil {
-		log.Fatalf("unable to parse CassandraDB config at %v: %v", *cassandraDBConfigJSON, err)
+	// Only attempt to load/generate config if actually testing
+	// This is only needed since we are requiring configs for these tests
+	if spec.PctCassandraRead > 0 {
+		if err := spec.CassandraDBConfig.FromJSON(*cassandraDBConfigJSON); err != nil {
+			log.Fatalf("unable to parse CassandraDB config at %v: %v", *cassandraDBConfigJSON, err)
+		}
+
+		if err := spec.CassandraDBRoleConfig.FromJSON(*cassandraDBRoleConfigJSON); err != nil {
+			log.Fatalf("unable to parse CassandraDB Role config at %v: %v", *cassandraDBRoleConfigJSON, err)
+		}
 	}
 
-	if err := spec.CassandraDBRoleConfig.FromJSON(*cassandraDBRoleConfigJSON); err != nil {
-		log.Fatalf("unable to parse CassandraDB Role config at %v: %v", *cassandraDBRoleConfigJSON, err)
+	if spec.PctLDAPLogin > 0 {
+		if err := spec.LDAPAuthConfig.FromJSON(*ldapConfigJSON); err != nil {
+			log.Fatalf("unable to parse LDAP Config at %v: %v", *ldapConfigJSON, err)
+		}
+
+		if err := spec.LDAPTestUserConfig.FromJSON(*ldapTestUserCredsJSON); err != nil {
+			log.Fatalf("unable to parse test LDAP user credentials at %v: %v", *ldapTestUserCredsJSON, err)
+		}
 	}
 
 	switch *reportMode {

--- a/vegeta/target_auth_ldap.go
+++ b/vegeta/target_auth_ldap.go
@@ -1,0 +1,191 @@
+package vegeta
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/api"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+)
+
+type ldaptest struct {
+	pathPrefix string
+	authUser   string
+	authPass   string
+	header     http.Header
+}
+
+type LDAPAuthConfig struct {
+	URL                  string   `json:"url"`
+	CaseSensitiveNames   bool     `json:"case_sensitive_names"`
+	RequestTimeout       int      `json:"request_timeout"`
+	StartTLS             bool     `json:"starttls"`
+	TLSMinVersion        string   `json:"tls_min_version"`
+	TLSMaxVersion        string   `json:"tls_max_version"`
+	InsecureTLS          bool     `json:"insecure_tls"`
+	Certificate          string   `json:"certificate"`
+	ClientTLSCert        string   `json:"client_tls_cert"`
+	ClientTLSKey         string   `json:"client_tls_key"`
+	BindDN               string   `json:"binddn"`
+	BindPass             string   `json:"bindpass"`
+	UserDN               string   `json:"userdn"`
+	UserAttr             string   `json:"userattr"`
+	DiscoverDN           string   `json:"discoverdn"`
+	DenyNullBind         bool     `json:"deny_null_bind"`
+	UPNDomain            string   `json:"upndomain"`
+	UserFilter           string   `json:"userfilter"`
+	AnonymousGroupSearch bool     `json:"anonymous_group_search"`
+	GroupFilter          string   `json:"group_filter"`
+	GroupDN              string   `json:"groupdn"`
+	GroupAttr            string   `json:"groupattr"`
+	UsernameAsAlias      bool     `json:"username_as_alias"`
+	TokenTTL             int      `json:"token_ttl"`
+	TokenMaxTTL          int      `json:"token_max_ttl"`
+	TokenPolicies        []string `json:"token_policies"`
+	TokenBoundCIDRs      []string `json:"token_bound_cidrs"`
+	TokenExplicitMaxTTL  int      `json:"token_explicit_max_ttl"`
+	TokenNoDefaultPolicy bool     `json:"token_no_default_policy"`
+	TokenNumUses         int      `json:"token_num_uses"`
+	TokenPeriod          int      `json:"token_period"`
+	TokenType            string   `json:"token_type"`
+}
+
+type LDAPTestUserConfig struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func (c *LDAPAuthConfig) FromJSON(path string) error {
+	// Set Defaults
+	c.TLSMinVersion = "tls12"
+	c.TLSMaxVersion = "tls12"
+
+	if path == "" {
+		return fmt.Errorf("no LDAP Config passed but is required")
+	}
+
+	// Load JSON config
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(c); err != nil {
+		return err
+	}
+
+	// Check for required fields
+	switch {
+	case c.URL == "":
+		return fmt.Errorf("no LDAP server url provided but is required")
+	case c.GroupDN == "":
+		return fmt.Errorf("no groupdn provided but is required")
+	default:
+		return nil
+	}
+}
+
+func (u *LDAPTestUserConfig) FromJSON(path string) error {
+	if path == "" {
+		return fmt.Errorf("no LDAP user config passed but is required")
+	}
+
+	// Load JSON config
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(u); err != nil {
+		return err
+	}
+
+	// Check for required fields
+	switch {
+	case u.Username == "":
+		return fmt.Errorf("no username passed but is required")
+	case u.Password == "":
+		return fmt.Errorf("no password passed but is required")
+	default:
+		return nil
+	}
+}
+
+func (l *ldaptest) login(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: "POST",
+		URL:    client.Address() + l.pathPrefix + "/login/" + l.authUser,
+		Header: l.header,
+		Body:   []byte(fmt.Sprintf(`{"password": "%s"}`, l.authPass)),
+	}
+}
+
+func setupLDAPAuth(client *api.Client, randomMounts bool, config *LDAPAuthConfig, testUserConfig *LDAPTestUserConfig) (*ldaptest, error) {
+	authPath, err := uuid.GenerateUUID()
+	if err != nil {
+		panic("can't create UUID")
+	}
+	if !randomMounts {
+		authPath = "ldap"
+	}
+
+	err = client.Sys().EnableAuthWithOptions(authPath, &api.EnableAuthOptions{
+		Type: "ldap",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error enabling ldap: %v", err)
+	}
+
+	// Write LDAP config
+	_, err = client.Logical().Write("auth/"+authPath+"/config", map[string]interface{}{
+		"url":                     config.URL,
+		"case_sensitive_names":    config.CaseSensitiveNames,
+		"request_timeout":         config.RequestTimeout,
+		"starttls":                config.StartTLS,
+		"tls_min_version":         config.TLSMinVersion,
+		"tls_max_version":         config.TLSMaxVersion,
+		"insecure_tls":            config.InsecureTLS,
+		"certificate":             config.Certificate,
+		"client_tls_cert":         config.ClientTLSCert,
+		"client_tls_key":          config.ClientTLSKey,
+		"binddn":                  config.BindDN,
+		"bindpass":                config.BindPass,
+		"userdn":                  config.UserDN,
+		"userattr":                config.UserAttr,
+		"discoverdn":              config.DiscoverDN,
+		"deny_null_bind":          config.DenyNullBind,
+		"upndomain":               config.UPNDomain,
+		"userfilter":              config.UserFilter,
+		"anonymous_group_search":  config.AnonymousGroupSearch,
+		"group_filter":            config.GroupFilter,
+		"groupdn":                 config.GroupDN,
+		"groupattr":               config.GroupAttr,
+		"username_as_alias":       config.UsernameAsAlias,
+		"token_ttl":               config.TokenTTL,
+		"token_max_ttl":           config.TokenMaxTTL,
+		"token_policies":          config.TokenPolicies,
+		"token_bound_cidrs":       config.TokenBoundCIDRs,
+		"token_explicit_max_ttl":  config.TokenExplicitMaxTTL,
+		"token_no_default_policy": config.TokenNoDefaultPolicy,
+		"token_num_uses":          config.TokenNumUses,
+		"token_period":            config.TokenPeriod,
+		"token_type":              config.TokenType,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error writing LDAP config: %v", err)
+	}
+
+	return &ldaptest{
+		header:     http.Header{"X-Vault-Token": []string{client.Token()}, "X-Vault-Namespace": []string{client.Headers().Get("X-Vault-Namespace")}},
+		pathPrefix: "/v1/" + filepath.Join("auth", authPath),
+		authUser:   testUserConfig.Username,
+		authPass:   testUserConfig.Password,
+	}, nil
+}

--- a/vegeta/targets.go
+++ b/vegeta/targets.go
@@ -125,6 +125,9 @@ type TestSpecification struct {
 	PctCassandraRead      int
 	CassandraDBConfig     CassandraDBConfig
 	CassandraDBRoleConfig CassandraRoleConfig
+	PctLDAPLogin          int
+	LDAPAuthConfig        LDAPAuthConfig
+	LDAPTestUserConfig    LDAPTestUserConfig
 }
 
 func BuildTargets(spec TestSpecification, client *api.Client, caPEM string, clientCAPem string) (*TargetMulti, error) {
@@ -195,6 +198,19 @@ func BuildTargets(spec TestSpecification, client *api.Client, caPEM string, clie
 			pathPrefix: cert.pathPrefix,
 			percent:    spec.PctCertLogin,
 			target:     cert.login,
+		})
+	}
+	if spec.PctLDAPLogin > 0 {
+		ldap, err := setupLDAPAuth(client, spec.RandomMounts, &spec.LDAPAuthConfig, &spec.LDAPTestUserConfig)
+		if err != nil {
+			return nil, err
+		}
+		tm.fractions = append(tm.fractions, targetFraction{
+			name:       "LDAP login",
+			method:     "POST",
+			pathPrefix: ldap.pathPrefix,
+			percent:    spec.PctLDAPLogin,
+			target:     ldap.login,
 		})
 	}
 	if spec.PctPkiIssue > 0 {


### PR DESCRIPTION
This PR adds a benchmark test for LDAP Auth. Configuration for the method itself as well as a config file containing user credentials for the benchmark to use are required.