### PR TITLE
Implement SSH Signing benchmark test

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Tests options:
 - `pct_ldap_login`: percent of requests that are LDAP logins
 - `pct_k8s_login`: percent of requests that are Kubernetes logins
 - `pct_postgresql_read`: percent of requests that are PostgreSQL credential generations
+- `pct_ssh_sign`: percent of requests that are SSH Client Key Sign operations
 
 There is also a `numkvs` option: if any kvv1 or kvv2 requests are specified,
 then this many keys will be written during the setup phase.  The read operations
@@ -168,6 +169,34 @@ data:
 ```
 
 Please refer to the [Vault Kubernetes Auth Method](https://www.vaultproject.io/api-docs/auth/kubernetes) documentation for all available configuration options.
+
+## SSH Key Signing
+
+This benchmark will test throughput for SSH Key Signing. This test defaults to Client Key signing, but you can provide configuration for both the CA and Signer Role by using the `ssh_signer_ca_config_json` and `ssh_signer_role_config_json` flags respectively. Default configurations are as follows:
+
+`/ssh/config/ca`
+```
+{
+  "generate_signing_key": true,
+  "key_type": "ssh-rsa",
+  "key_bits": 0,
+}
+```
+
+`/ssh/roles/:name`
+```
+{
+  "name": "benchmark-role",
+  "port": 22,
+	"key_bits": 1024,
+	"algorithm_signer": "default",
+	"not_before_duration": "30s",
+	"key_type": "ca",
+	"allow_user_certificates": true,
+}
+```
+
+Please refer to the [SSH Secrets Engine](https://developer.hashicorp.com/vault/api-docs/secret/ssh) documenation for all available configuration options.
 
 # Outputs
 

--- a/main.go
+++ b/main.go
@@ -63,6 +63,8 @@ func main() {
 		couchbaseRoleConfigJSON   = flag.String("couchbase_role_config_json", "", "when specified, path to Couchbase benchmark role configuration JSON file to use")
 		kubernetesConfigJSON      = flag.String("k8s_config_json", "", "path to JSON file containing Vault Kubernetes Auth configuration")
 		kubernetesRoleConfigJSON  = flag.String("k8s_role_config_json", "", "path to JSON file containing Kubernetes Role configuration to use for Kubernetes Auth benchmarking")
+		sshSignerCAConfigJSON     = flag.String("ssh_signer_ca_config_json", "", "when specified, path to SSH Signer CA Config JSON file to use")
+		sshSignerRoleConfigJSON   = flag.String("ssh_signer_role_config_json", "", "when specified, path to SSH Signer Role Config JSON file to use")
 	)
 
 	// test-related settings
@@ -90,6 +92,7 @@ func main() {
 	flag.IntVar(&spec.PctPostgreSQLRead, "pct_postgresql_read", 0, "percent of requests that are PostgreSQL credential generations")
 	flag.IntVar(&spec.PctCouchbaseRead, "pct_couchbase_read", 0, "percent of requests that are Couchbase dynamic credential generations")
 	flag.IntVar(&spec.PctKubernetesLogin, "pct_k8s_login", 0, "percent of requests that are Kubernetes logins")
+	flag.IntVar(&spec.PctSSHSign, "pct_ssh_sign", 0, "percent of requests that are SSH Client Key Sign operations")
 
 	// Config Options
 	flag.DurationVar(&spec.PkiConfig.SetupDelay, "pki_setup_delay", 50*time.Millisecond, "When running PKI tests, delay after creating mount before attempting issuer creation")
@@ -173,6 +176,15 @@ func main() {
 
 		if err := spec.KubernetesTestRoleConfig.FromJSON(*kubernetesRoleConfigJSON); err != nil {
 			log.Fatalf("unable to parse Kubernetes role config at %v: %v", *kubernetesRoleConfigJSON, err)
+		}
+	}
+
+	if spec.PctSSHSign > 0 {
+		if err := spec.SSHSignerCAConfig.FromJSON(*sshSignerCAConfigJSON); err != nil {
+			log.Fatalf("unable to parse SSH CA config at %v: %v", *sshSignerCAConfigJSON, err)
+		}
+		if err := spec.SSHSignerRoleConfig.FromJSON(*sshSignerRoleConfigJSON); err != nil {
+			log.Fatalf("unable to parse SSH CA config at %v: %v", *sshSignerRoleConfigJSON, err)
 		}
 	}
 

--- a/vegeta/target_secret_ssh_sign.go
+++ b/vegeta/target_secret_ssh_sign.go
@@ -1,0 +1,220 @@
+package vegeta
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/api"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+	"golang.org/x/crypto/ssh"
+)
+
+/*
+/ssh/sign/:role_name
+*/
+
+type sshSigntest struct {
+	pathPrefix   string
+	role         string
+	publicKeyRSA string
+	header       http.Header
+}
+
+type SSHSignerCAConfig struct {
+	PrivateKey         string
+	PublicKey          string
+	GenerateSigningKey bool
+	KeyType            string
+	KeyBits            int
+}
+
+type SSHSignerRoleConfig struct {
+	Name                   string
+	Key                    string
+	AdminUser              string
+	DefaultUser            string
+	DefaultUserTemplate    bool
+	CIDRList               []string
+	ExcludeCIDRList        []string
+	Port                   int
+	KeyType                string
+	KeyBits                int
+	InstallScript          string
+	AllowedUsers           []string
+	AllowedUsersTemplate   bool
+	AllowedDomains         []string
+	KeyOptionSpecs         []string
+	TTL                    string
+	MaxTTL                 string
+	AllowedCriticalOptions []string
+	AllowedExtensions      []string
+	DefaultCriticalOptions map[string]string
+	DefaultExtensions      map[string]string
+	AllowUserCertificates  bool
+	AllowHostCertificates  bool
+	AllowBareDomains       bool
+	AllowSubdomains        bool
+	AllowUserKeyIDs        bool
+	KeyIDFormat            string
+	AllowedUserKeyLengths  map[string]interface{}
+	AlgorithmSigner        string
+	NotBeforeDuration      string
+}
+
+func (c *SSHSignerCAConfig) FromJSON(path string) error {
+	c.GenerateSigningKey = true
+	c.KeyType = "ssh-rsa"
+	c.KeyBits = 0
+
+	if path == "" {
+		return nil
+	}
+
+	// Then load JSON config
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *SSHSignerRoleConfig) FromJSON(path string) error {
+	r.Port = 22
+	r.KeyBits = 1024
+	r.AlgorithmSigner = "default"
+	r.NotBeforeDuration = "30s"
+	r.KeyType = "ca"
+	r.AllowUserCertificates = true
+
+	if path == "" {
+		return nil
+	}
+
+	// Then load JSON config
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *sshSigntest) sign(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: "POST",
+		URL:    client.Address() + s.pathPrefix + "/sign/" + s.role,
+		Header: s.header,
+		Body:   []byte(fmt.Sprintf(`{"public_key": "%s"}`, s.publicKeyRSA)),
+	}
+}
+
+func setupSSHSign(client *api.Client, randomMounts bool, caConfig *SSHSignerCAConfig, roleConfig *SSHSignerRoleConfig) (*sshSigntest, error) {
+	sshSignerPath, err := uuid.GenerateUUID()
+	if err != nil {
+		panic("can't create UUID")
+	}
+	if !randomMounts {
+		sshSignerPath = "ssh-signer"
+	}
+
+	// Enable SSH Secrets Engine
+	err = client.Sys().Mount(sshSignerPath, &api.MountInput{
+		Type: "ssh",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error enabling ssh: %v", err)
+	}
+
+	// Write Config for CA
+	sshCAConfigPath := filepath.Join(sshSignerPath, "config", "ca")
+	_, err = client.Logical().Write(sshCAConfigPath, map[string]interface{}{
+		"generate_signing_key": caConfig.GenerateSigningKey,
+		"private_key":          caConfig.PrivateKey,
+		"public_key":           caConfig.PublicKey,
+		"key_type":             caConfig.KeyType,
+		"key_bits":             caConfig.KeyBits,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error generating signing key: %v", err)
+	}
+
+	// Create Role
+	role := "benchmark-role"
+	if roleConfig.Name != "" {
+		role = roleConfig.Name
+	}
+	rolePath := filepath.Join(sshSignerPath, "roles", role)
+	_, err = client.Logical().Write(rolePath, map[string]interface{}{
+		"key":                      roleConfig.Key,
+		"admin_user":               roleConfig.AdminUser,
+		"default_user":             roleConfig.DefaultUser,
+		"default_user_template":    roleConfig.DefaultUserTemplate,
+		"cidr_list":                roleConfig.CIDRList,
+		"exclude_cidr_list":        roleConfig.ExcludeCIDRList,
+		"port":                     roleConfig.Port,
+		"key_type":                 roleConfig.KeyType,
+		"key_bits":                 roleConfig.KeyBits,
+		"install_script":           roleConfig.InstallScript,
+		"allowed_users":            roleConfig.AllowedUsers,
+		"allower_users_template":   roleConfig.AllowedUsersTemplate,
+		"allowed_domains":          roleConfig.AllowedDomains,
+		"key_option_specs":         roleConfig.KeyOptionSpecs,
+		"ttl":                      roleConfig.TTL,
+		"max_ttl":                  roleConfig.MaxTTL,
+		"allowed_critical_options": roleConfig.AllowedCriticalOptions,
+		"allowed_extensions":       roleConfig.AllowedExtensions,
+		"default_critical_options": roleConfig.DefaultCriticalOptions,
+		"default_extensions":       roleConfig.DefaultExtensions,
+		"allow_user_certificates":  roleConfig.AllowUserCertificates,
+		"allow_host_certificates":  roleConfig.AllowHostCertificates,
+		"allow_bare_domains":       roleConfig.AllowBareDomains,
+		"allow_subdomains":         roleConfig.AllowSubdomains,
+		"allow_user_key_ids":       roleConfig.AllowUserKeyIDs,
+		"key_id_format":            roleConfig.KeyIDFormat,
+		"allowed_user_key_lengths": roleConfig.AllowedUserKeyLengths,
+		"algorithm_signer":         roleConfig.AlgorithmSigner,
+		"not_before_duration":      roleConfig.NotBeforeDuration,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error creating ssh signer role %q: %v", role, err)
+	}
+
+	// Generate Public Key to sign
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, fmt.Errorf("error generating test RSA key-pair: %v", err)
+	}
+
+	// Get Public
+	publicKey, err := ssh.NewPublicKey(privateKey.Public())
+	if err != nil {
+		return nil, fmt.Errorf("error generating test RSA public key: %v", err)
+	}
+
+	publicKeyRSA := "ssh-rsa " + base64.StdEncoding.EncodeToString(publicKey.Marshal())
+
+	return &sshSigntest{
+		header:       http.Header{"X-Vault-Token": []string{client.Token()}, "X-Vault-Namespace": []string{client.Headers().Get("X-Vault-Namespace")}},
+		pathPrefix:   "/v1/" + filepath.Join(sshSignerPath),
+		role:         role,
+		publicKeyRSA: publicKeyRSA,
+	}, nil
+}

--- a/vegeta/targets.go
+++ b/vegeta/targets.go
@@ -137,6 +137,9 @@ type TestSpecification struct {
 	PctKubernetesLogin       int
 	KubernetesAuthConfig     KubernetesAuthConfig
 	KubernetesTestRoleConfig KubernetesTestRoleConfig
+	PctSSHSign               int
+	SSHSignerCAConfig        SSHSignerCAConfig
+	SSHSignerRoleConfig      SSHSignerRoleConfig
 }
 
 func BuildTargets(spec TestSpecification, client *api.Client, caPEM string, clientCAPem string) (*TargetMulti, error) {
@@ -380,6 +383,19 @@ func BuildTargets(spec TestSpecification, client *api.Client, caPEM string, clie
 			pathPrefix: couchbase.pathPrefix,
 			percent:    spec.PctCouchbaseRead,
 			target:     couchbase.read,
+		})
+	}
+	if spec.PctSSHSign > 0 {
+		sshSign, err := setupSSHSign(client, spec.RandomMounts, &spec.SSHSignerCAConfig, &spec.SSHSignerRoleConfig)
+		if err != nil {
+			return nil, err
+		}
+		tm.fractions = append(tm.fractions, targetFraction{
+			name:       "ssh pub key sign",
+			method:     "POST",
+			pathPrefix: sshSign.pathPrefix,
+			percent:    spec.PctSSHSign,
+			target:     sshSign.sign,
 		})
 	}
 


### PR DESCRIPTION
This PR implements SSH the SSH signing benchmark test. The test defaults to SSH Client Public Key Signing, but takes in configuration so you can also do Host Key signing as well.