### PR TITLE
Add Option to Use Non-Random Mounts

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	// test-related settings
 	var spec = vegeta.TestSpecification{}
-	flag.BoolVar(&spec.RandomMounts, "random_mounts", true, "use random mount paths for each test")
+	flag.BoolVar(&spec.RandomMounts, "random_mounts", true, "use random mount path names for each test")
 	flag.IntVar(&spec.NumKVs, "numkvs", 1000, "num KVs to use for KV operations")
 	flag.IntVar(&spec.KVSize, "kvsize", 1, "num KVs to use for KV operations")
 	flag.DurationVar(&spec.TokenTTL, "token_ttl", time.Hour, "ttl to use for logins")


### PR DESCRIPTION
This adds a test parameter to Benchmark-Vault that will allow non-randomly generated mount names to be used.  The default mount names are defined in the individual test files. `-random_mounts` defaults to `true` if not defined.

```console
$ vault secrets list
Path          Type         Accessor              Description
----          ----         --------              -----------
cubbyhole/    cubbyhole    cubbyhole_838f3251    per-token private secret storage
identity/     identity     identity_dac76d2e     identity store
secret/       kv           kv_4ca09206           key/value secret storage
sys/          system       system_cd1c777a       system endpoints used for control, policy and debugging

$ ./benchmark-vault \
>  -vault_addr=http://localhost:8200 \
>  -vault_token=root \
>  -pct_rabbitmq_read=100 \
>  -rabbitmq_config_json='path/to/rabbitmq_config.json' \
>  -rabbitmq_role_config_json='path/to/rabbitmq_role_config.json' \
>  -random_mounts=false
http://localhost:8200
op                     count  rate        throughput  mean         95th%        99th%         successRatio
rabbit cred retrieval  8200   811.459467  763.176992  12.557175ms  14.069128ms  114.040714ms  100.00%

$ vault secrets list
Path          Type         Accessor              Description
----          ----         --------              -----------
cubbyhole/    cubbyhole    cubbyhole_838f3251    per-token private secret storage
identity/     identity     identity_dac76d2e     identity store
rabbit/       rabbitmq     rabbitmq_310ef848     n/a
secret/       kv           kv_4ca09206           key/value secret storage
sys/          system       system_cd1c777a       system endpoints used for control, policy and debugging

$ ./benchmark-vault \
>  -vault_addr=http://localhost:8200 \
>  -vault_token=root \
>  -pct_rabbitmq_read=100 \
>  -rabbitmq_config_json='path/to/rabbitmq_config.json' \
>  -rabbitmq_role_config_json='path/to/rabbitmq_role_config.json'
http://localhost:8200
op                     count  rate        throughput  mean         95th%         99th%         successRatio
rabbit cred retrieval  1501   143.739553  143.616932  69.587585ms  646.719661ms  794.642118ms  100.00%

$ vault secrets list
Path                                     Type         Accessor              Description
----                                     ----         --------              -----------
97d15fa2-6667-6448-7bbb-82c47f30fda3/    rabbitmq     rabbitmq_ec70e995     n/a
cubbyhole/                               cubbyhole    cubbyhole_838f3251    per-token private secret storage
identity/                                identity     identity_dac76d2e     identity store
rabbit/                                  rabbitmq     rabbitmq_310ef848     n/a
secret/                                  kv           kv_4ca09206           key/value secret storage
sys/                                     system       system_cd1c777a       system endpoints used for control, policy and debugging
```