### PR TITLE
Remove redundant revoking of leases in cassandra and postgres

### DIFF
--- a/vegeta/target_secret_cassandra.go
+++ b/vegeta/target_secret_cassandra.go
@@ -122,13 +122,7 @@ func (c *cassandratest) read(client *api.Client) vegeta.Target {
 func (c *cassandratest) cleanup(client *api.Client) error {
 	client.SetClientTimeout(c.timeout)
 
-	// Revoke all leases
-	_, err := client.Logical().Write(strings.Replace(c.pathPrefix, "/v1/", "/sys/leases/revoke-prefix/", 1), map[string]interface{}{})
-	if err != nil {
-		return fmt.Errorf("error cleaning up leases: %v", err)
-	}
-
-	_, err = client.Logical().Delete(strings.Replace(c.pathPrefix, "/v1/", "/sys/mounts/", 1))
+	_, err := client.Logical().Delete(strings.Replace(c.pathPrefix, "/v1/", "/sys/mounts/", 1))
 
 	if err != nil {
 		return fmt.Errorf("error cleaning up mount: %v", err)

--- a/vegeta/target_secret_postgresql.go
+++ b/vegeta/target_secret_postgresql.go
@@ -119,13 +119,7 @@ func (c *postgresqltest) read(client *api.Client) vegeta.Target {
 func (c *postgresqltest) cleanup(client *api.Client) error {
 	client.SetClientTimeout(c.timeout)
 
-	// Revoke all leases
-	_, err := client.Logical().Write(strings.Replace(c.pathPrefix, "/v1/", "/sys/leases/revoke-prefix/", 1), map[string]interface{}{})
-	if err != nil {
-		return fmt.Errorf("error cleaning up leases: %v", err)
-	}
-
-	_, err = client.Logical().Delete(strings.Replace(c.pathPrefix, "/v1/", "/sys/mounts/", 1))
+	_, err := client.Logical().Delete(strings.Replace(c.pathPrefix, "/v1/", "/sys/mounts/", 1))
 
 	if err != nil {
 		return fmt.Errorf("error cleaning up mount: %v", err)


### PR DESCRIPTION
Cassandra and postgres secrets engines had `cleanup` functions that revoked all leases and then disabled the secrets mount. This is redundant because disabling the secrets mount already revokes all leases. 