### PR TITLE
remove "_config" from block attributes as it is implied in the parent block

### DIFF
--- a/benchmarktests/target_auth_approle.go
+++ b/benchmarktests/target_auth_approle.go
@@ -45,8 +45,8 @@ type ApproleTestConfig struct {
 
 // Intermediary struct to assist with HCL decoding
 type ApproleAuthTestConfig struct {
-	RoleConfig     *RoleConfig     `hcl:"role_config,block"`
-	SecretIDConfig *SecretIDConfig `hcl:"secret_id_config,block"`
+	RoleConfig     *RoleConfig     `hcl:"role,block"`
+	SecretIDConfig *SecretIDConfig `hcl:"secret_id,block"`
 }
 
 // AppRole Role Config

--- a/benchmarktests/target_auth_jwt.go
+++ b/benchmarktests/target_auth_jwt.go
@@ -52,8 +52,8 @@ type JWTTestConfig struct {
 
 // Intermediary struct to assist with HCL decoding
 type JWTAuthTestConfig struct {
-	JWTAuthConfig *JWTAuthConfig `hcl:"auth_config,block"`
-	JWTRoleConfig *JWTRoleConfig `hcl:"role_config,block"`
+	JWTAuthConfig *JWTAuthConfig `hcl:"auth,block"`
+	JWTRoleConfig *JWTRoleConfig `hcl:"role,block"`
 }
 
 // JWT Auth Config

--- a/benchmarktests/target_auth_ldap.go
+++ b/benchmarktests/target_auth_ldap.go
@@ -46,8 +46,8 @@ type LDAPTestConfig struct {
 }
 
 type LDAPAuthTestConfig struct {
-	LDAPAuthConfig     *LDAPAuthConfig     `hcl:"auth_config,block"`
-	LDAPTestUserConfig *LDAPTestUserConfig `hcl:"test_user_config,block"`
+	LDAPAuthConfig     *LDAPAuthConfig     `hcl:"auth,block"`
+	LDAPTestUserConfig *LDAPTestUserConfig `hcl:"test_user,block"`
 }
 
 type LDAPAuthConfig struct {

--- a/benchmarktests/target_secret_consul.go
+++ b/benchmarktests/target_secret_consul.go
@@ -41,8 +41,8 @@ type ConsulTestConfig struct {
 }
 
 type ConsulSecretTestConfig struct {
-	ConsulConfig     *ConsulConfig     `hcl:"consul_config,block"`
-	ConsulRoleConfig *ConsulRoleConfig `hcl:"role_config,block"`
+	ConsulConfig     *ConsulConfig     `hcl:"consul,block"`
+	ConsulRoleConfig *ConsulRoleConfig `hcl:"role,block"`
 }
 
 type ConsulConfig struct {

--- a/benchmarktests/target_secret_elasticsearch.go
+++ b/benchmarktests/target_secret_elasticsearch.go
@@ -40,8 +40,8 @@ type ElasticSearchTestConfig struct {
 }
 
 type ElasticSearchSecretTestConfig struct {
-	ElasticSearchConfig     *ElasticSearchConfig     `hcl:"db_config,block"`
-	ElasticSearchRoleConfig *ElasticSearchRoleConfig `hcl:"role_config,block"`
+	ElasticSearchConfig     *ElasticSearchConfig     `hcl:"db,block"`
+	ElasticSearchRoleConfig *ElasticSearchRoleConfig `hcl:"role,block"`
 }
 
 type ElasticSearchConfig struct {

--- a/benchmarktests/target_secret_mongo.go
+++ b/benchmarktests/target_secret_mongo.go
@@ -42,8 +42,8 @@ type MongoDBTestConfig struct {
 }
 
 type MongoDBSecretTestConfig struct {
-	MongoDBConfig     *MongoDBConfig     `hcl:"db_config,block"`
-	MongoDBRoleConfig *MongoDBRoleConfig `hcl:"role_config,block"`
+	MongoDBConfig     *MongoDBConfig     `hcl:"db,block"`
+	MongoDBRoleConfig *MongoDBRoleConfig `hcl:"role,block"`
 }
 
 type MongoDBConfig struct {

--- a/benchmarktests/target_secret_postgres.go
+++ b/benchmarktests/target_secret_postgres.go
@@ -47,8 +47,8 @@ type PostgreSQLTestConfig struct {
 
 // Intermediary struct to assist with HCL decoding
 type PostgreSQLSecretTestConfig struct {
-	PostgreSQLDBConfig   *PostgreSQLDBConfig   `hcl:"db_config,block"`
-	PostgreSQLRoleConfig *PostgreSQLRoleConfig `hcl:"role_config,block"`
+	PostgreSQLDBConfig   *PostgreSQLDBConfig   `hcl:"db,block"`
+	PostgreSQLRoleConfig *PostgreSQLRoleConfig `hcl:"role,block"`
 }
 
 // PostgreSQL DB Config

--- a/benchmarktests/target_secret_transit.go
+++ b/benchmarktests/target_secret_transit.go
@@ -50,11 +50,11 @@ type TransitTestConfig struct {
 type TransitConfig struct {
 	PayloadLen           int                   `hcl:"payload_len,optional"`
 	ContextLen           int                   `hcl:"context_len,optional"`
-	TransitConfigKeys    *TransitConfigKeys    `hcl:"keys_config,block"`
-	TransitConfigSign    *TransitConfigSign    `hcl:"sign_config,block"`
-	TransitConfigVerify  *TransitConfigVerify  `hcl:"verify_config,block"`
-	TransitConfigEncrypt *TransitConfigEncrypt `hcl:"encrypt_config,block"`
-	TransitConfigDecrypt *TransitConfigDecrypt `hcl:"decrypt_config,block"`
+	TransitConfigKeys    *TransitConfigKeys    `hcl:"keys,block"`
+	TransitConfigSign    *TransitConfigSign    `hcl:"sign,block"`
+	TransitConfigVerify  *TransitConfigVerify  `hcl:"verify,block"`
+	TransitConfigEncrypt *TransitConfigEncrypt `hcl:"encrypt,block"`
+	TransitConfigDecrypt *TransitConfigDecrypt `hcl:"decrypt,block"`
 }
 
 // /transit/keys/:name


### PR DESCRIPTION
This PR removes `_config` from subconfig block attributes as it is implied being in the parent `config` block.