### PR TITLE
add global vault_namespace config param

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -39,6 +39,7 @@ type RunCommand struct {
 	flagAuditPath        string
 	flagVBCoreConfigPath string
 	flagCAPEMFile        string
+	flagVaultNamespace   string
 	flagWorkers          int
 	flagRPS              int
 	flagDuration         time.Duration
@@ -98,6 +99,14 @@ func (r *RunCommand) Flags() *FlagSets {
 		Target:  &r.flagVaultToken,
 		Default: "",
 		Usage:   "Vault Token to be used for test setup.",
+	})
+
+	f.StringVar(&StringVar{
+		Name:    "vault_namespace",
+		EnvVar:  "VAULT_NAMESPACE",
+		Target:  &r.flagVaultNamespace,
+		Usage:   "Vault Namespace to create test mounts.",
+		Default: "",
 	})
 
 	f.StringVar(&StringVar{
@@ -346,6 +355,7 @@ func (r *RunCommand) Run(args []string) int {
 			return 1
 		}
 		client.SetToken(cluster.Token)
+		client.SetNamespace(conf.VaultNamespace)
 		clients = append(clients, client)
 	}
 
@@ -509,6 +519,14 @@ func (r *RunCommand) applyConfigOverrides(f *FlagSets, config *vbConfig.VaultBen
 		Default: "http://127.0.0.1:8200",
 	})
 	config.VaultAddr = r.flagVaultAddr
+
+	r.setStringFlag(f, config.VaultNamespace, &StringVar{
+		Name:    "vault_namespace",
+		EnvVar:  "VAULT_NAMESPACE",
+		Target:  &r.flagVaultNamespace,
+		Default: "",
+	})
+	config.VaultNamespace = r.flagVaultNamespace
 
 	r.setStringFlag(f, config.ReportMode, &StringVar{
 		Name:    "report_mode",

--- a/config/config.go
+++ b/config/config.go
@@ -21,24 +21,25 @@ const (
 )
 
 type VaultBenchmarkCoreConfig struct {
-	Remain        hcl.Body                          `hcl:",remain"`
-	VaultAddr     string                            `hcl:"vault_addr,optional"`
-	VaultToken    string                            `hcl:"vault_token,optional"`
-	Duration      string                            `hcl:"duration,optional"`
-	ReportMode    string                            `hcl:"report_mode,optional"`
-	AuditPath     string                            `hcl:"audit_path,optional"`
-	Annotate      string                            `hcl:"annotate,optional"`
-	ClusterJSON   string                            `hcl:"cluster_json,optional"`
-	CAPEMFile     string                            `hcl:"ca_pem_file,optional"`
-	PPROFInterval string                            `hcl:"pprof_interval,optional"`
-	Tests         []*benchmarktests.BenchmarkTarget `hcl:"test,block"`
-	RPS           int                               `hcl:"rps,optional"`
-	Workers       int                               `hcl:"workers,optional"`
-	RandomMounts  bool                              `hcl:"random_mounts,optional"`
-	InputResults  bool                              `hcl:"input_results,optional"`
-	Cleanup       bool                              `hcl:"cleanup,optional"`
-	Debug         bool                              `hcl:"debug,optional"`
-	LogLevel      string                            `hcl:"log_level,optional"`
+	Remain         hcl.Body                          `hcl:",remain"`
+	VaultAddr      string                            `hcl:"vault_addr,optional"`
+	VaultToken     string                            `hcl:"vault_token,optional"`
+	VaultNamespace string                            `hcl:"vault_namespace,optional"`
+	Duration       string                            `hcl:"duration,optional"`
+	ReportMode     string                            `hcl:"report_mode,optional"`
+	AuditPath      string                            `hcl:"audit_path,optional"`
+	Annotate       string                            `hcl:"annotate,optional"`
+	ClusterJSON    string                            `hcl:"cluster_json,optional"`
+	CAPEMFile      string                            `hcl:"ca_pem_file,optional"`
+	PPROFInterval  string                            `hcl:"pprof_interval,optional"`
+	Tests          []*benchmarktests.BenchmarkTarget `hcl:"test,block"`
+	RPS            int                               `hcl:"rps,optional"`
+	Workers        int                               `hcl:"workers,optional"`
+	RandomMounts   bool                              `hcl:"random_mounts,optional"`
+	InputResults   bool                              `hcl:"input_results,optional"`
+	Cleanup        bool                              `hcl:"cleanup,optional"`
+	Debug          bool                              `hcl:"debug,optional"`
+	LogLevel       string                            `hcl:"log_level,optional"`
 }
 
 func NewVaultBenchmarkCoreConfig() *VaultBenchmarkCoreConfig {


### PR DESCRIPTION
This PR adds a global namespace config parameter as well as flag to allow a clearer configuration pattern of setting a namespace rather than just relying on the `VAULT_NAMESPACE` env var.