### PR TITLE
Disable cgo on builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dist:
 
 .PHONY: bin
 bin: dist
-	GOARCH=$(ARCH) GOOS=$(OS) go build -o $(BIN)
+	CGO_ENABLED=0 GOARCH=$(ARCH) GOOS=$(OS) go build -o $(BIN)
 
 .PHONY: build
 build:


### PR DESCRIPTION
It looks like CGO is enabled on builds for benchmark. Trying to disable them explicitly in the Makefile.

```bash
[~]$ ./vault-benchmark -v
./vault-benchmark: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ./vault-benchmark)
```