### PR TITLE
Remove oss metadata from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on: [workflow_dispatch, push]
 
 env:
   PKG_NAME: "vault-benchmark"
-  METADATA: """
+  METADATA: ""
 
 jobs:
   get-go-version:


### PR DESCRIPTION
Metadata is being added to the version flag:

```bash
[~] ./vault-benchmark -version
vault-benchmark v0.1.0+oss
```

There's no need for this since it's only an OSS project.