### PR TITLE
Remove cgo from crt build script

### DIFF
--- a/scripts/crt-build.sh
+++ b/scripts/crt-build.sh
@@ -75,7 +75,7 @@ function build() {
 
   # Build vault-benchmark
   echo "$msg"
-  go build -o "$BIN_PATH" -tags "$GO_TAGS" -ldflags "$ldflags" -trimpath -buildvcs=false
+  CGO_ENABLED=0 go build -o "$BIN_PATH" -tags "$GO_TAGS" -ldflags "$ldflags" -trimpath -buildvcs=false
 }
 
 # Run the CRT Builder


### PR DESCRIPTION
CRT build script isn't using the Makefile so have to disable CGO from that script too.