### PR TITLE
Adjust location of examples in docs

### DIFF
--- a/docs/tests/auth-approle.md
+++ b/docs/tests/auth-approle.md
@@ -2,6 +2,39 @@
 
 This benchmark tests the performance of logins using the AppRole auth method.
 
+## Example HCL
+
+```hcl
+test "approle_auth" "approle_test1" {
+  weight = 100
+  config {
+    role {
+      role_name         = "test"
+      bind_secret_id    = true
+      token_ttl         = "10m"
+      token_type = "batch"
+    }
+
+    secret_id {
+      token_bound_cidrs = ["1.2.3.4/32"]
+      ttl               = "10m"
+    }
+  }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-04-26T13:02:59.943-0500 [INFO]  vault-benchmark: setting up targets
+2023-04-26T13:02:59.993-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-04-26T13:03:01.994-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://localhost:8200
+op              count  rate         throughput   mean        95th%       99th%       successRatio
+approle_test1  8794   4396.873590  4394.241423  2.273698ms  3.164222ms  4.351606ms  100.00%
+```
+
 ## Benchmark Configuration Parameters
 
 ### Role Configuration (`role`)
@@ -81,36 +114,3 @@ include a-Z, 0-9, space, hyphen, underscore and periods.
   after which this SecretID expires. A value of zero will allow the SecretID to not expire.
   Overrides `secret_id_ttl` role option when supplied.
   May not be longer than role's `secret_id_ttl`.
-
-## Example HCL
-
-```hcl
-test "approle_auth" "approle_test1" {
-  weight = 100
-  config {
-    role {
-      role_name         = "test"
-      bind_secret_id    = true
-      token_ttl         = "10m"
-      token_type = "batch"
-    }
-
-    secret_id {
-      token_bound_cidrs = ["1.2.3.4/32"]
-      ttl               = "10m"
-    }
-  }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-04-26T13:02:59.943-0500 [INFO]  vault-benchmark: setting up targets
-2023-04-26T13:02:59.993-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
-2023-04-26T13:03:01.994-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://localhost:8200
-op              count  rate         throughput   mean        95th%       99th%       successRatio
-approle_test1  8794   4396.873590  4394.241423  2.273698ms  3.164222ms  4.351606ms  100.00%
-```

--- a/docs/tests/auth-certificate.md
+++ b/docs/tests/auth-certificate.md
@@ -2,6 +2,30 @@
 
 This benchmark tests the performance of logins using the Certificate auth method.
 
+## Example HCL
+
+```hcl
+test "cert_auth" "cert_auth_test1" {
+  weight = 25
+  config {
+    name = "test"
+  certificate = cert.pem
+  }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-04-26T14:50:27.124-0500 [INFO]  vault-benchmark: setting up targets
+2023-04-26T14:50:27.135-0500 [INFO]  vault-benchmark: starting benchmarks: duration=3s
+2023-04-26T14:50:30.136-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://localhost:8200
+op               count  rate         throughput  mean        95th%      99th%       successRatio
+cert_auth_test1  22203  7401.042556  0.000000    1.348606ms  1.84933ms  2.458901ms  0.00%
+```
+
 ## Benchmark Configuration Parameters
 
 - `name` `(string: "benchmark-vault")` - The name of the certificate role.
@@ -80,27 +104,3 @@ This benchmark tests the performance of logins using the Certificate auth method
   additional possibilities: `default-service` and `default-batch` which specify
   the type to return unless the client requests a different type at generation
   time.
-
-## Example HCL
-
-```hcl
-test "cert_auth" "cert_auth_test1" {
-  weight = 25
-  config {
-    name = "test"
-  certificate = cert.pem
-  }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-04-26T14:50:27.124-0500 [INFO]  vault-benchmark: setting up targets
-2023-04-26T14:50:27.135-0500 [INFO]  vault-benchmark: starting benchmarks: duration=3s
-2023-04-26T14:50:30.136-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://localhost:8200
-op               count  rate         throughput  mean        95th%      99th%       successRatio
-cert_auth_test1  22203  7401.042556  0.000000    1.348606ms  1.84933ms  2.458901ms  0.00%
-```

--- a/docs/tests/auth-jwt.md
+++ b/docs/tests/auth-jwt.md
@@ -2,6 +2,38 @@
 
 This benchmark tests the performance of logins using the jwt auth method.
 
+## Example HCL
+
+```hcl
+test "jwt_auth" "jwt_auth1" {
+  weight = 100
+  config {
+    auth {
+      jwks_url = "jwks.com"
+    }
+
+    role {
+      name            = "my-jwt-role"
+      role_type       = "jwt"
+      bound_audiences = ["https://vault.plugin.auth.jwt.test"]
+      user_claim      = "https://vault/user"
+    }
+  }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-04-26T17:52:03.294-0500 [INFO]  vault-benchmark: setting up targets
+2023-04-26T17:52:03.320-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-04-26T17:52:05.322-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://localhost:8200
+op         count  rate         throughput   mean        95th%       99th%       successRatio
+jwt_auth1  8837   4418.525130  4416.285509  2.262041ms  3.135816ms  4.338269ms  100.00%
+```
+
 ## Benchmark Configuration Parameters
 
 ### JWT Authentication Configuration (`auth`)`
@@ -111,35 +143,3 @@ This benchmark tests the performance of logins using the jwt auth method.
   additional possibilities: `default-service` and `default-batch` which specify
   the type to return unless the client requests a different type at generation
   time.
-
-## Example HCL
-
-```hcl
-test "jwt_auth" "jwt_auth1" {
-  weight = 100
-  config {
-    auth {
-      jwks_url = "jwks.com"
-    }
-
-    role {
-      name            = "my-jwt-role"
-      role_type       = "jwt"
-      bound_audiences = ["https://vault.plugin.auth.jwt.test"]
-      user_claim      = "https://vault/user"
-    }
-  }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-04-26T17:52:03.294-0500 [INFO]  vault-benchmark: setting up targets
-2023-04-26T17:52:03.320-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
-2023-04-26T17:52:05.322-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://localhost:8200
-op         count  rate         throughput   mean        95th%       99th%       successRatio
-jwt_auth1  8837   4418.525130  4416.285509  2.262041ms  3.135816ms  4.338269ms  100.00%
-```

--- a/docs/tests/auth-ldap.md
+++ b/docs/tests/auth-ldap.md
@@ -2,6 +2,50 @@
 
 This benchmark will test LDAP Authentication to Vault. The primary required fields are `url` and `groupdn` depending on the LDAP environment setup and desired connection method.
 
+### Test User Config `role`
+
+- `username` `(string: "")`: LDAP test username. This can also be provided via the
+`VAULT_BENCHMARK_LDAP_TEST_USERNAME` environment variable.
+- `password` `(string: "")`: LDAP test user password. This can also be provided via the
+`VAULT_BENCHMARK_LDAP_TEST_PASSWORD` environment variable.
+
+## Example HCL
+
+```hcl
+test "ldap_auth" "ldap_auth_test1" {
+    weight = 100
+    config {
+        auth {
+            url         = "ldap://localhost"
+            userdn      = "ou=users,dc=hashicorp,dc=com"
+            groupdn     = "ou=groups,dc=hashicorp,dc=com"
+            binddn      = "cn=admin,dc=hashicorp,dc=com"
+            bindpass    = "admin"
+            userattr    = "uid"
+            groupattr   = "cn"
+            groupfilter = "(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))"
+            token_policies = ["default","test"]
+        }
+        test_user  {
+            username = "alice"
+            password = "password"
+        }
+    }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-04-26T18:11:50.901-0500 [INFO]  vault-benchmark: setting up targets
+2023-04-26T18:11:50.918-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-04-26T18:11:52.920-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://localhost:8200
+op               count  rate         throughput  mean        95th%       99th%       successRatio
+ldap_auth_test1  13345  6671.750122  0.000000    1.495695ms  2.128745ms  3.542841ms  100.00%
+```
+
 ## Test Parameters
 
 ### Auth Configuration `auth`
@@ -102,47 +146,3 @@ This benchmark will test LDAP Authentication to Vault. The primary required fiel
   additional possibilities: `default-service` and `default-batch` which specify
   the type to return unless the client requests a different type at generation
   time.
-
-### Test User Config `role`
-
-- `username` `(string: "")`: LDAP test username. This can also be provided via the
-`VAULT_BENCHMARK_LDAP_TEST_USERNAME` environment variable.
-- `password` `(string: "")`: LDAP test user password. This can also be provided via the
-`VAULT_BENCHMARK_LDAP_TEST_PASSWORD` environment variable.
-
-## Example HCL
-
-```hcl
-test "ldap_auth" "ldap_auth_test1" {
-    weight = 100
-    config {
-        auth {
-            url         = "ldap://localhost"
-            userdn      = "ou=users,dc=hashicorp,dc=com"
-            groupdn     = "ou=groups,dc=hashicorp,dc=com"
-            binddn      = "cn=admin,dc=hashicorp,dc=com"
-            bindpass    = "admin"
-            userattr    = "uid"
-            groupattr   = "cn"
-            groupfilter = "(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))"
-            token_policies = ["default","test"]
-        }
-        test_user  {
-            username = "alice"
-            password = "password"
-        }
-    }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-04-26T18:11:50.901-0500 [INFO]  vault-benchmark: setting up targets
-2023-04-26T18:11:50.918-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
-2023-04-26T18:11:52.920-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://localhost:8200
-op               count  rate         throughput  mean        95th%       99th%       successRatio
-ldap_auth_test1  13345  6671.750122  0.000000    1.495695ms  2.128745ms  3.542841ms  100.00%
-```

--- a/docs/tests/auth-userpass.md
+++ b/docs/tests/auth-userpass.md
@@ -2,6 +2,30 @@
 
 This benchmark tests the performance of logins using the userpass auth method.
 
+## Example HCL
+
+```hcl
+test "userpass_auth" "userpass_test1" {
+    weight = 100
+    config {
+        username = "test-user"
+        password = "password"
+    }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-04-27T08:25:52.436-0500 [INFO]  vault-benchmark: setting up targets
+2023-04-27T08:25:52.558-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-04-27T08:25:54.638-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://localhost:8200
+op              count  rate        throughput  mean         95th%        99th%         successRatio
+userpass_test1  257    128.275142  123.740847  79.775804ms  99.824563ms  106.657676ms  100.00%
+```
+
 ## Test Parameters
 
 ### Userpass Configuration `config`
@@ -39,27 +63,3 @@ This benchmark tests the performance of logins using the userpass auth method.
   additional possibilities: `default-service` and `default-batch` which specify
   the type to return unless the client requests a different type at generation
   time.
-
-## Example HCL
-
-```hcl
-test "userpass_auth" "userpass_test1" {
-    weight = 100
-    config {
-        username = "test-user"
-        password = "password"
-    }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-04-27T08:25:52.436-0500 [INFO]  vault-benchmark: setting up targets
-2023-04-27T08:25:52.558-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
-2023-04-27T08:25:54.638-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://localhost:8200
-op              count  rate        throughput  mean         95th%        99th%         successRatio
-userpass_test1  257    128.275142  123.740847  79.775804ms  99.824563ms  106.657676ms  100.00%
-```

--- a/docs/tests/secret-cassandra.md
+++ b/docs/tests/secret-cassandra.md
@@ -2,6 +2,38 @@
 
 This benchmark will test the dynamic generation of Cassandra credentials.
 
+### Example HCL
+
+```hcl
+test "cassandra_secret" "cassandra_secret_1" {
+    weight = 100
+    config {
+        db_connection {
+            hosts =  "127.0.0.1"
+            username = "cassandra"
+            password = "cassandra"
+            protocol_version = "3"
+        }
+
+        role {
+            creation_statements = "CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER; GRANT SELECT ON ALL KEYSPACES TO {{username}};"
+        }
+    }
+}
+```
+
+### Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-04-27T13:36:04.553-0500 [INFO]  vault-benchmark: setting up targets
+2023-04-27T13:36:04.768-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-04-27T13:36:07.662-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://localhost:8200
+op                  count  rate       throughput  mean         95th%         99th%      successRatio
+cassandra_secret_1  34     16.635150  11.754942   739.57933ms  852.527624ms  859.465ms  100.00%
+```
+
 ## Test Parameters
 
 ### DB Connection Configuration `db_connection`
@@ -79,35 +111,3 @@ permissions to do so.
   executed to rollback a create operation in the event of an error. Not every
   plugin type will support this functionality. See the plugin's API page for
   more information on support and formatting for this parameter.
-
-### Example HCL
-
-```hcl
-test "cassandra_secret" "cassandra_secret_1" {
-    weight = 100
-    config {
-        db_connection {
-            hosts =  "127.0.0.1"
-            username = "cassandra"
-            password = "cassandra"
-            protocol_version = "3"
-        }
-
-        role {
-            creation_statements = "CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER; GRANT SELECT ON ALL KEYSPACES TO {{username}};"
-        }
-    }
-}
-```
-
-### Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-04-27T13:36:04.553-0500 [INFO]  vault-benchmark: setting up targets
-2023-04-27T13:36:04.768-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
-2023-04-27T13:36:07.662-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://localhost:8200
-op                  count  rate       throughput  mean         95th%         99th%      successRatio
-cassandra_secret_1  34     16.635150  11.754942   739.57933ms  852.527624ms  859.465ms  100.00%
-```

--- a/docs/tests/secret-consul.md
+++ b/docs/tests/secret-consul.md
@@ -2,6 +2,38 @@
 
 This benchmark will test the dynamic generation of Consul credentials.
 
+## Example HCL
+
+```hcl
+test "consul_secret" "consul_test_1" {
+    weight = 100
+    config {
+        version = "1.8.0"
+        consul_config {
+            address = "127.0.0.1:8500"
+        }
+        role_config {
+            node_identities = [
+                "client-1:dc1",
+                "client-2:dc1"
+            ]
+        }
+    }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-04-27T12:57:07.469-0500 [INFO]  vault-benchmark: setting up targets
+2023-04-27T12:57:07.476-0500 [INFO]  vault-benchmark: starting benchmarks: duration=5s
+2023-04-27T12:57:12.479-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://127.0.0.1:8200
+op             count  rate         throughput   mean        95th%       99th%        successRatio
+consul_test_1  12463  2492.488399  2491.245115  4.007578ms  6.123533ms  17.388957ms  100.00%
+```
+
 ## Test Parameters `config`
 
 - `version` `(string: "1.14.0")` - Specifies the version of Consul. This is used to determine the correct API calls to make.
@@ -62,35 +94,3 @@ This benchmark will test the dynamic generation of Consul credentials.
   The partition must exist, and the Consul policies or roles assigned to the
   Vault role must also exist inside the given partition. If not provided, the partition `default`
   is used.
-
-## Example HCL
-
-```hcl
-test "consul_secret" "consul_test_1" {
-    weight = 100
-    config {
-        version = "1.8.0"
-        consul_config {
-            address = "127.0.0.1:8500"
-        }
-        role_config {
-            node_identities = [
-                "client-1:dc1",
-                "client-2:dc1"
-            ]
-        }
-    }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-04-27T12:57:07.469-0500 [INFO]  vault-benchmark: setting up targets
-2023-04-27T12:57:07.476-0500 [INFO]  vault-benchmark: starting benchmarks: duration=5s
-2023-04-27T12:57:12.479-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://127.0.0.1:8200
-op             count  rate         throughput   mean        95th%       99th%        successRatio
-consul_test_1  12463  2492.488399  2491.245115  4.007578ms  6.123533ms  17.388957ms  100.00%
-```

--- a/docs/tests/secret-couchbase.md
+++ b/docs/tests/secret-couchbase.md
@@ -2,6 +2,39 @@
 
 This benchmark will test the dynamic generation of Couchbase credentials.
 
+### Example Configuration
+
+```hcl
+test "couchbase_secret" "couchbase_test_1" {
+    weight = 100
+    config {
+        db_connection {
+            username = "username"
+            password = "password"
+            hosts = "couchbase://127.0.0.1"
+            bucket_name = "benchmark-vault"
+        }
+
+        role {
+                default_ttl = "5m"
+                max_ttl = "1h"
+        }
+    }
+}
+```
+
+### Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+Setting up targets...
+Starting benchmarks. Will run for 1s...
+Benchmark complete!
+Target: http://127.0.0.1:8200
+op                count  rate        throughput  mean         95th%         99th%         successRatio
+couchbase_test_1  109    108.336919  100.456417  97.007399ms  151.364911ms  172.702436ms  100.00%
+```
+
 ## Test Parameters
 
 ### DB Configuration `db_connection`
@@ -77,36 +110,3 @@ This benchmark will test the dynamic generation of Couchbase credentials.
   serialized JSON string array, or a base64-encoded serialized JSON string
   array. The `{{username}}` value will be substituted. If not provided, defaults to
   a reasonable default alter user statement.
-
-### Example Configuration
-
-```hcl
-test "couchbase_secret" "couchbase_test_1" {
-    weight = 100
-    config {
-        db_connection {
-            username = "username"
-            password = "password"
-            hosts = "couchbase://127.0.0.1"
-            bucket_name = "benchmark-vault"
-        }
-
-        role {
-                default_ttl = "5m"
-                max_ttl = "1h"
-        }
-    }
-}
-```
-
-### Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-Setting up targets...
-Starting benchmarks. Will run for 1s...
-Benchmark complete!
-Target: http://127.0.0.1:8200
-op                count  rate        throughput  mean         95th%         99th%         successRatio
-couchbase_test_1  109    108.336919  100.456417  97.007399ms  151.364911ms  172.702436ms  100.00%
-```

--- a/docs/tests/secret-elasticsearch.md
+++ b/docs/tests/secret-elasticsearch.md
@@ -2,6 +2,38 @@
 
 This benchmark will test the dynamic generation of Elasticsearch credentials.
 
+## Example Configuration
+
+```hcl
+test "elasticsearch_secret" "elasticsearch_test_1" {
+    weight = 100
+    config {
+        db_connection {
+            url = "https://localhost:9200"
+            username = "elastic"
+            password = "pass"
+        }
+        role {
+            creation_statements = ["{\"elasticsearch_role_definition\": {\"indices\": [{\"names\":[\"*\"], \"privileges\":[\"read\"]}]}}"]
+            default_ttl = "1h"
+            max_ttl = "24h"
+        }
+    }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-05-01T12:57:50.575-0500 [INFO]  vault-benchmark: setting up targets
+2023-05-01T12:57:50.713-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-05-01T12:57:52.902-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://127.0.0.1:8200
+op                   count  rate       throughput  mean          95th%        99th%         successRatio
+elasticsearch_test1  107    52.860797  48.892726   197.742375ms  291.00526ms  382.716563ms  100.00%
+```
+
 ## Test Parameters
 
 ### Elasticsearch Database Config `db_connection`
@@ -39,35 +71,3 @@ This benchmark will test the dynamic generation of Elasticsearch credentials.
 - `creation_statements` `(list)` – Specifies the database
   statements executed to create and configure a user. See the plugin's API page
   for more information on support and formatting for this parameter.
-
-## Example Configuration
-
-```hcl
-test "elasticsearch_secret" "elasticsearch_test_1" {
-    weight = 100
-    config {
-        db_connection {
-            url = "https://localhost:9200"
-            username = "elastic"
-            password = "pass"
-        }
-        role {
-            creation_statements = ["{\"elasticsearch_role_definition\": {\"indices\": [{\"names\":[\"*\"], \"privileges\":[\"read\"]}]}}"]
-            default_ttl = "1h"
-            max_ttl = "24h"
-        }
-    }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-05-01T12:57:50.575-0500 [INFO]  vault-benchmark: setting up targets
-2023-05-01T12:57:50.713-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
-2023-05-01T12:57:52.902-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://127.0.0.1:8200
-op                   count  rate       throughput  mean          95th%        99th%         successRatio
-elasticsearch_test1  107    52.860797  48.892726   197.742375ms  291.00526ms  382.716563ms  100.00%
-```

--- a/docs/tests/secret-kv.md
+++ b/docs/tests/secret-kv.md
@@ -2,15 +2,6 @@
 
 This benchmark tests the performance of KVV1 and/or KVV2.  It writes a set number of keys (KV1 or KV2) to each mount, then reads them back.
 
-## Test Parameters
-
-### Configuration `config`
-
-- `numkvs` `(int: 1000)` - if any kvv1 or kvv2 requests are specified,
-then this many keys will be written during the setup phase.  The read operations
-will read from these keys, and the write operations overwrite them.
-- `kvsize` `(int: 1)`:  the size of the key and value to write.
-
 ## Example Configuration
 
 ```hcl
@@ -42,3 +33,12 @@ op               count  rate         throughput   mean        95th%       99th% 
 kvv2_read_test   7372   3685.483957  3684.373734  1.350193ms  1.932011ms  2.427874ms  100.00%
 kvv2_write_test  7476   3738.104588  3736.361605  1.3383ms    1.94206ms   2.438648ms  100.00%
 ```
+
+## Test Parameters
+
+### Configuration `config`
+
+- `numkvs` `(int: 1000)` - if any kvv1 or kvv2 requests are specified,
+then this many keys will be written during the setup phase.  The read operations
+will read from these keys, and the write operations overwrite them.
+- `kvsize` `(int: 1)`:  the size of the key and value to write.

--- a/docs/tests/secret-mongo.md
+++ b/docs/tests/secret-mongo.md
@@ -2,6 +2,37 @@
 
 This benchmark will test the dynamic generation of MongoDB credentials.
 
+## Example Configuration
+
+```hcl
+test "mongodb_secret" "mongodb_test_1" {
+    weight = 100
+    config {
+        db_connection {
+            name = "mongo-benchmark-database"
+            connection_url = "mongodb://{{username}}:{{password}}@127.0.0.1:27017/admin?tls=false"
+            username = "mdbadmin"
+            password = "root"
+        }
+        role {
+            db_name = "mongo-benchmark-database"
+        }
+    }
+}
+```
+
+### Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+Setting up targets...
+Starting benchmarks. Will run for 10s...
+Benchmark complete!
+Target: http://127.0.0.1:8200
+op              count  rate       throughput  mean          95th%         99th%         successRatio
+mongodb_test_1  473    47.284284  46.300585   213.963008ms  222.443684ms  228.1842ms  100.00%
+```
+
 ## Test Parameters
 
 ### MongoDB Database Configuration `db_connection`
@@ -58,34 +89,3 @@ This benchmark will test the dynamic generation of MongoDB credentials.
   be executed to revoke a user. Must be a serialized JSON object, or a base64-encoded
   serialized JSON object. The object can optionally contain a `db` string. If no
   `db` value is provided, it defaults to the `admin` database.
-
-## Example Configuration
-
-```hcl
-test "mongodb_secret" "mongodb_test_1" {
-    weight = 100
-    config {
-        db_connection {
-            name = "mongo-benchmark-database"
-            connection_url = "mongodb://{{username}}:{{password}}@127.0.0.1:27017/admin?tls=false"
-            username = "mdbadmin"
-            password = "root"
-        }
-        role {
-            db_name = "mongo-benchmark-database"
-        }
-    }
-}
-```
-
-### Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-Setting up targets...
-Starting benchmarks. Will run for 10s...
-Benchmark complete!
-Target: http://127.0.0.1:8200
-op              count  rate       throughput  mean          95th%         99th%         successRatio
-mongodb_test_1  473    47.284284  46.300585   213.963008ms  222.443684ms  228.1842ms  100.00%
-```

--- a/docs/tests/secret-mssql.md
+++ b/docs/tests/secret-mssql.md
@@ -2,36 +2,6 @@
 
 This benchmark will test the dynamic generation of MSSQL credentials.
 
-## Test Parameters
-
-### DB Connection Configuration `db_connection`
-
-- `name` `(string: "benchmark-mssql")` - Name for this database connection. This is specified as part of the URL.
-- `plugin_name` `(string: "mssql-database-plugin")` - Specifies the name of the plugin to use for this connection.
-- `plugin_version` `(string: "")` - Specifies the semantic version of the plugin to use for this connection.
-- `verify_connection` `(bool: true)` - Specifies if the connection is verified during initial configuration. Defaults to true.
-- `allowed_roles` `(list: ["benchmark_role"])` - List of the roles allowed to use this connection.
-- `root_rotation_statements` `(list: [])` - Specifies the database statements to be executed to rotate the root user's credentials.
-- `password_policy` `(string: "")` - The name of the password policy to use when generating passwords for this database. If not specified, this will use a default policy defined as: 20 characters with at least 1 uppercase, 1 lowercase, 1 number, and 1 dash character.
-- `connection_url` `(string: <required>)` - Specifies the MSSQL DSN. This field can be templated and supports passing the username and password parameters in the following format `{{field_name}}`. A templated connection URL is required when using root credential rotation.
-- `disable_escaping` `(boolean: false)` - Turns off the escaping of special characters inside of the username and password fields. See the [databases secrets engine docs](https://developer.hashicorp.com/vault/docs/secrets/databases#disable-character-escaping) for more information. Defaults to `false`.
-- `contained_db` `(bool: false)` - If set, specifies that the connection being configured is to a [Contained Database](https://docs.microsoft.com/en-us/sql/relational-databases/databases/contained-databases?view=sql-server-ver15), like AzureSQL.
-- `max_open_connections` `(int: 4)` - Specifies the maximum number of open connections to the database.
-- `max_idle_connections` `(int: 0)` - Specifies the maximum number of idle connections to the database. A zero uses the value of `max_open_connections` and a negative value disables idle connections. If larger than `max_open_connections` it will be reduced to be equal.
-- `max_connection_lifetime` `(string: "0s")` - Specifies the maximum amount of time a connection may be reused. If <= `0s` connections are reused forever.
-- `username` `(string: <required>)` - The root credential username used in the connection URL. Can also be set using the `VAULT_BENCHMARK_MSSQL_USERNAME` environment variable.
-- `password` `(string: <required>)` - The root credential password used in the connection URL. Can also be set using the `VAULT_BENCHMARK_MSSQL_PASSWORD` environment variable.
-- `username_template` `(string: "")` - [Template](https://developer.hashicorp.com/vault/docs/concepts/username-templating) describing how dynamic usernames are generated.
-
-### Role Configuration `role`
-
-- `name` `(string: "benchmark-role")` - Specifies the name of the role to create. This is specified as part of the URL.
-- `db_name` `(string: "benchmark-mssql")` - The name of the database connection to use for this role.
-- `default_ttl` `(string: "")` - Specifies the TTL for the leases associated with this role. Accepts time suffixed strings (`1h`). Defaults to system/engine default TTL time.
-- `max_ttl` `(string: "")` - Specifies the maximum TTL for the leases associated with this role. Accepts time suffixed strings (`1h`). Defaults to `sys/mounts`'s default TTL time; this value is allowed to be less than the mount max TTL (or, if not set, the system max TTL), but it is not allowed to be longer. See also [The TTL General Case](https://developer.hashicorp.com/vault/docs/concepts/tokens#the-general-case).
-- `creation_statements` `(list: <required>)` – Specifies the database  statements executed to create and configure a user. Must be a semicolon-separated string, a base64-encoded semicolon-separated string, a serialized JSON string array, or a base64-encoded serialized JSON string array. The `{{name}}` and `{{password}}` values will be substituted.
-- `revocation_statements` `(list: [])` – Specifies the database statements to be executed to revoke a user. Must be a semicolon-separated string, a base64-encoded semicolon-separated string, a serialized JSON string array, or a base64-encoded serialized JSON string array. The `{{name}}` value will be substituted. If not provided defaults to a generic drop user statement.
-
 ## Example Configuration
 
 ```hcl
@@ -63,3 +33,33 @@ Target: http://127.0.0.1:8200
 op              count  rate       throughput  mean          95th%         99th%         successRatio
 mssql_secret_1  94     93.214668  83.761150   114.236245ms  187.749698ms  188.590625ms  100.00%
 ```
+
+## Test Parameters
+
+### DB Connection Configuration `db_connection`
+
+- `name` `(string: "benchmark-mssql")` - Name for this database connection. This is specified as part of the URL.
+- `plugin_name` `(string: "mssql-database-plugin")` - Specifies the name of the plugin to use for this connection.
+- `plugin_version` `(string: "")` - Specifies the semantic version of the plugin to use for this connection.
+- `verify_connection` `(bool: true)` - Specifies if the connection is verified during initial configuration. Defaults to true.
+- `allowed_roles` `(list: ["benchmark_role"])` - List of the roles allowed to use this connection.
+- `root_rotation_statements` `(list: [])` - Specifies the database statements to be executed to rotate the root user's credentials.
+- `password_policy` `(string: "")` - The name of the password policy to use when generating passwords for this database. If not specified, this will use a default policy defined as: 20 characters with at least 1 uppercase, 1 lowercase, 1 number, and 1 dash character.
+- `connection_url` `(string: <required>)` - Specifies the MSSQL DSN. This field can be templated and supports passing the username and password parameters in the following format `{{field_name}}`. A templated connection URL is required when using root credential rotation.
+- `disable_escaping` `(boolean: false)` - Turns off the escaping of special characters inside of the username and password fields. See the [databases secrets engine docs](https://developer.hashicorp.com/vault/docs/secrets/databases#disable-character-escaping) for more information. Defaults to `false`.
+- `contained_db` `(bool: false)` - If set, specifies that the connection being configured is to a [Contained Database](https://docs.microsoft.com/en-us/sql/relational-databases/databases/contained-databases?view=sql-server-ver15), like AzureSQL.
+- `max_open_connections` `(int: 4)` - Specifies the maximum number of open connections to the database.
+- `max_idle_connections` `(int: 0)` - Specifies the maximum number of idle connections to the database. A zero uses the value of `max_open_connections` and a negative value disables idle connections. If larger than `max_open_connections` it will be reduced to be equal.
+- `max_connection_lifetime` `(string: "0s")` - Specifies the maximum amount of time a connection may be reused. If <= `0s` connections are reused forever.
+- `username` `(string: <required>)` - The root credential username used in the connection URL. Can also be set using the `VAULT_BENCHMARK_MSSQL_USERNAME` environment variable.
+- `password` `(string: <required>)` - The root credential password used in the connection URL. Can also be set using the `VAULT_BENCHMARK_MSSQL_PASSWORD` environment variable.
+- `username_template` `(string: "")` - [Template](https://developer.hashicorp.com/vault/docs/concepts/username-templating) describing how dynamic usernames are generated.
+
+### Role Configuration `role`
+
+- `name` `(string: "benchmark-role")` - Specifies the name of the role to create. This is specified as part of the URL.
+- `db_name` `(string: "benchmark-mssql")` - The name of the database connection to use for this role.
+- `default_ttl` `(string: "")` - Specifies the TTL for the leases associated with this role. Accepts time suffixed strings (`1h`). Defaults to system/engine default TTL time.
+- `max_ttl` `(string: "")` - Specifies the maximum TTL for the leases associated with this role. Accepts time suffixed strings (`1h`). Defaults to `sys/mounts`'s default TTL time; this value is allowed to be less than the mount max TTL (or, if not set, the system max TTL), but it is not allowed to be longer. See also [The TTL General Case](https://developer.hashicorp.com/vault/docs/concepts/tokens#the-general-case).
+- `creation_statements` `(list: <required>)` – Specifies the database  statements executed to create and configure a user. Must be a semicolon-separated string, a base64-encoded semicolon-separated string, a serialized JSON string array, or a base64-encoded serialized JSON string array. The `{{name}}` and `{{password}}` values will be substituted.
+- `revocation_statements` `(list: [])` – Specifies the database statements to be executed to revoke a user. Must be a semicolon-separated string, a base64-encoded semicolon-separated string, a serialized JSON string array, or a base64-encoded serialized JSON string array. The `{{name}}` value will be substituted. If not provided defaults to a generic drop user statement.

--- a/docs/tests/secret-pki-issue.md
+++ b/docs/tests/secret-pki-issue.md
@@ -2,6 +2,39 @@
 
 This benchmark tests the performance of PKI issue operations.
 
+## Example Configuration
+
+```hcl
+test "pki_issue" "pki_issue_test1" {
+  weight = 100
+  config {
+      setup_delay="2s"
+      root_ca {
+        common_name = "benchmark.test"
+      }
+      intermediate_csr {
+        common_name = "benchmark.test Intermediate Authority"
+      }
+      role {
+        ttl = "10m"
+        key_type = "ed25519"
+      }
+  }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+Setting up targets...
+Starting benchmarks. Will run for 5s...
+Benchmark complete!
+Target: http://127.0.0.1:8200
+op               count  rate       throughput  mean          95th%         99th%         successRatio
+pki_issue_test1  257    51.218560  46.586545   201.743774ms  455.520239ms  560.106407ms  100.00%
+```
+
 ## Test Parameters
 
 ### Root CA Config `root`
@@ -772,36 +805,3 @@ See [Managed Keys](https://developer.hashicorp.com/vault/api-docs/secret/pki#man
   the role.
 
 Additional configuration examples can be found in the [pki configuration directory](/example-configs/pki/).
-
-## Example Configuration
-
-```hcl
-test "pki_issue" "pki_issue_test1" {
-  weight = 100
-  config {
-      setup_delay="2s"
-      root_ca {
-        common_name = "benchmark.test"
-      }
-      intermediate_csr {
-        common_name = "benchmark.test Intermediate Authority"
-      }
-      role {
-        ttl = "10m"
-        key_type = "ed25519"
-      }
-  }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-Setting up targets...
-Starting benchmarks. Will run for 5s...
-Benchmark complete!
-Target: http://127.0.0.1:8200
-op               count  rate       throughput  mean          95th%         99th%         successRatio
-pki_issue_test1  257    51.218560  46.586545   201.743774ms  455.520239ms  560.106407ms  100.00%
-```

--- a/docs/tests/secret-pki-sign.md
+++ b/docs/tests/secret-pki-sign.md
@@ -2,6 +2,41 @@
 
 This benchmark tests the performance of PKI signing operations.
 
+## Example Configuration
+
+```hcl
+test "pki_sign" "pki_sign_test1" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+        }
+        role {
+            ttl = "10m"
+        }
+        sign {
+            csr = "./MYCSR.csr"
+        }
+    }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+Setting up targets...
+Starting benchmarks. Will run for 5s...
+Benchmark complete!
+Target: http://127.0.0.1:8200
+op              count  rate         throughput   mean       95th%       99th%       successRatio
+pki_sign_test1  10759  2151.124964  2149.133615  4.64791ms  6.081656ms  8.258573ms  100.00%
+```
+
 ## Test Parameters
 
 ### Root CA Config `root`
@@ -784,38 +819,3 @@ See [Managed Keys](https://developer.hashicorp.com/vault/api-docs/secret/pki#man
   the role.
 
 Additional configuration examples can be found in the [pki configuration directory](/example-configs/pki/).
-
-## Example Configuration
-
-```hcl
-test "pki_sign" "pki_sign_test1" {
-    weight = 100
-    config {
-        setup_delay="2s"
-        root_ca {
-            common_name = "benchmark.test"
-        }
-        intermediate_csr {
-            common_name = "benchmark.test Intermediate Authority"
-        }
-        role {
-            ttl = "10m"
-        }
-        sign {
-            csr = "./MYCSR.csr"
-        }
-    }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-Setting up targets...
-Starting benchmarks. Will run for 5s...
-Benchmark complete!
-Target: http://127.0.0.1:8200
-op              count  rate         throughput   mean       95th%       99th%       successRatio
-pki_sign_test1  10759  2151.124964  2149.133615  4.64791ms  6.081656ms  8.258573ms  100.00%
-```

--- a/docs/tests/secret-postgresql.md
+++ b/docs/tests/secret-postgresql.md
@@ -2,6 +2,37 @@
 
 This benchmark will test the dynamic generation of PostgreSQL credentials.
 
+## Example Configuration
+
+```hcl
+test "postgresql_secret" "postgres_test_1" {
+    weight = 100
+    config {
+        db_connection {
+            connection_url = "postgresql://{{username}}:{{password}}@localhost:5432/postgres"
+            username = "username"
+            password = "password"
+        }
+
+        role {
+            creation_statements = "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";"
+        }
+    }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-05-01T21:10:03.140-0500 [INFO]  vault-benchmark: setting up targets
+2023-05-01T21:10:03.222-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-05-01T21:10:05.282-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://127.0.0.1:8200
+op               count  rate        throughput  mean         95th%        99th%        successRatio
+postgres_test_1  455    226.219503  220.930941  44.864053ms  63.980785ms  77.447877ms  100.00%
+```
+
 ## Test Parameters
 
 ### DB Config `db_connection`
@@ -79,34 +110,3 @@ This benchmark will test the dynamic generation of PostgreSQL credentials.
   serialized JSON string array, or a base64-encoded serialized JSON string
   array. The `{{name}}` and `{{password}}` values will be substituted. The
   generated password will be a random alphanumeric 20 character string.
-
-## Example Configuration
-
-```hcl
-test "postgresql_secret" "postgres_test_1" {
-    weight = 100
-    config {
-        db_connection {
-            connection_url = "postgresql://{{username}}:{{password}}@localhost:5432/postgres"
-            username = "username"
-            password = "password"
-        }
-
-        role {
-            creation_statements = "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";"
-        }
-    }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-05-01T21:10:03.140-0500 [INFO]  vault-benchmark: setting up targets
-2023-05-01T21:10:03.222-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
-2023-05-01T21:10:05.282-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://127.0.0.1:8200
-op               count  rate        throughput  mean         95th%        99th%        successRatio
-postgres_test_1  455    226.219503  220.930941  44.864053ms  63.980785ms  77.447877ms  100.00%
-```

--- a/docs/tests/secret-rabbit.md
+++ b/docs/tests/secret-rabbit.md
@@ -2,15 +2,6 @@
 
 This benchmark will test RabbitMQ secret engine operations. In order to use this test, configuration for the RabbitMQ server must be provided as an HCL file with a `rabbitmq_config` body.  Additionally, a `role_config` can also be provided.  The configuration options can be found in the [RabbitMQ Vault documentation](https://developer.hashicorp.com/vault/api-docs/secret/rabbitmq#configure-connection).  Example configuration files can be found in the [RabbitMQ configuration directory](/example-configs/rabbitmq/).
 
-## Default RabbitMQ Role Configuration
-
-```json
-{
-    "name": "benchmark-role",
-    "vhosts": "{\"/\":{\"write\": \".*\", \"read\": \".*\"}}"
-}
-```
-
 ## Example Usage
 
 ```bash
@@ -21,4 +12,13 @@ Benchmark complete!
 Target: http://127.0.0.1:8200
 op             count  rate        throughput  mean         95th%        99th%        successRatio
 rabbit_test_1  796    795.692431  791.605698  12.585419ms  23.516021ms  29.575085ms  100.00%
+```
+
+## Default RabbitMQ Role Configuration
+
+```json
+{
+    "name": "benchmark-role",
+    "vhosts": "{\"/\":{\"write\": \".*\", \"read\": \".*\"}}"
+}
 ```

--- a/docs/tests/secret-redis-dynamic.md
+++ b/docs/tests/secret-redis-dynamic.md
@@ -7,30 +7,6 @@ in your database when configuring the plugin. This user will be used to
 create/update/delete users within the database so it will need to have the appropriate
 permissions to do so.
 
-## Benchmark Configuration Parameters
-
-### Database Configuration (`db_connection`)
-
-- `name` `(string: "benchmark-redis-db")` - Name for this database connection.
-- `plugin_name` `(string: "redis-database-plugin")` - Specifies the name of the plugin to use for this connection.
-- `plugin_version` `(string: "")` - Specifies the semantic version of the plugin to use for this connection.
-- `verify_connection` `(bool: true)` – Specifies if the connection is verified during initial configuration. Defaults to true.
-- `host` `(string: <required>)` - Specifies the host to connect to.
-- `port` `(int: <required>)` - Specifies the port to connect to.
-- `username` `(string: <required>)` - The root credential username. This can also be provided via the `VAULT_BENCHMARK_REDIS_USERNAME` environment variable.
-- `password` `(string: <required>)` - The root credential password. This can also be provided via the `VAULT_BENCHMARK_REDIS_PASSWORD` environment variable.
-- `tls` `(bool: false)` - Specifies whether to use TLS when connecting to Redis.
-- `insecure_tls` `(bool: false)` - Specifies whether to skip verification of the server certificate when using TLS.
-- `ca_cert` `(string: optional)` - Specifies whether to use TLS when connecting to Redis.
-
-### Dynamic Role Configuration (`role`)
-
-- `name` `(string: "my-dynamic-role")` – Specifies the name of the role to create. This is specified as part of the URL.
-- `default_ttl` `(string)` - Specifies the TTL for the leases associated with this role. Accepts time suffixed strings (`1h`). Defaults to system/engine default TTL time.
-- `max_ttl` `(string)` - Specifies the maximum TTL for the leases associated with this role. Accepts time suffixed strings (`1h`). Defaults to `sys/mounts`'s default TTL time; this value is allowed to be less than the mount max TTL (or, if not set, the system max TTL), but it is not allowed to be longer. See also [The TTL General Case](/vault/docs/concepts/tokens#the-general-case).
-- `creation_statements` `(list: <required>)` – Specifies the database statements executed to create and configure a user. See the plugin's API page
-  for more information on support and formatting for this parameter.
-
 ## Example HCL
 
 ```hcl
@@ -68,3 +44,27 @@ Target: http://localhost:8200
 op                      count  rate         throughput   mean        95th%       99th%        successRatio
 redis_dynamic_secret_1  4922   2460.722400  2456.618212  4.065801ms  5.248935ms  10.719219ms  100.00%
 ```
+
+## Benchmark Configuration Parameters
+
+### Database Configuration (`db_connection`)
+
+- `name` `(string: "benchmark-redis-db")` - Name for this database connection.
+- `plugin_name` `(string: "redis-database-plugin")` - Specifies the name of the plugin to use for this connection.
+- `plugin_version` `(string: "")` - Specifies the semantic version of the plugin to use for this connection.
+- `verify_connection` `(bool: true)` – Specifies if the connection is verified during initial configuration. Defaults to true.
+- `host` `(string: <required>)` - Specifies the host to connect to.
+- `port` `(int: <required>)` - Specifies the port to connect to.
+- `username` `(string: <required>)` - The root credential username. This can also be provided via the `VAULT_BENCHMARK_REDIS_USERNAME` environment variable.
+- `password` `(string: <required>)` - The root credential password. This can also be provided via the `VAULT_BENCHMARK_REDIS_PASSWORD` environment variable.
+- `tls` `(bool: false)` - Specifies whether to use TLS when connecting to Redis.
+- `insecure_tls` `(bool: false)` - Specifies whether to skip verification of the server certificate when using TLS.
+- `ca_cert` `(string: optional)` - Specifies whether to use TLS when connecting to Redis.
+
+### Dynamic Role Configuration (`role`)
+
+- `name` `(string: "my-dynamic-role")` – Specifies the name of the role to create. This is specified as part of the URL.
+- `default_ttl` `(string)` - Specifies the TTL for the leases associated with this role. Accepts time suffixed strings (`1h`). Defaults to system/engine default TTL time.
+- `max_ttl` `(string)` - Specifies the maximum TTL for the leases associated with this role. Accepts time suffixed strings (`1h`). Defaults to `sys/mounts`'s default TTL time; this value is allowed to be less than the mount max TTL (or, if not set, the system max TTL), but it is not allowed to be longer. See also [The TTL General Case](/vault/docs/concepts/tokens#the-general-case).
+- `creation_statements` `(list: <required>)` – Specifies the database statements executed to create and configure a user. See the plugin's API page
+  for more information on support and formatting for this parameter.

--- a/docs/tests/secret-redis-static.md
+++ b/docs/tests/secret-redis-static.md
@@ -7,34 +7,6 @@ in your database when configuring the plugin. This user will be used to
 create/update/delete users within the database so it will need to have the appropriate
 permissions to do so.
 
-## Benchmark Configuration Parameters
-
-### DB Configuration (`db_connection`)
-
-- `name` `(string: "benchmark-redis-db")` - Name for this database connection.
-- `plugin_name` `(string: "redis-database-plugin")` - Specifies the name of the plugin to use for this connection.
-- `plugin_version` `(string: "")` - Specifies the semantic version of the plugin to use for this connection.
-- `verify_connection` `(bool: true)` – Specifies if the connection is verified during initial configuration. Defaults to true.
-- `allowed_roles` `(list: ["my-*-role"])` - List of the roles allowed to use this connection.
-- `host` `(string: <required>)` - Specifies the host to connect to.
-- `port` `(int: <required>)` - Specifies the port to connect to.
-- `username` `(string: <required>)` - The root credential username. This can also be provided via the `VAULT_BENCHMARK_STATIC_REDIS_USERNAME` environment variable.
-- `password` `(string: <required>)` - The root credential password. This can also be provided via the `VAULT_BENCHMARK_STATIC_REDIS_PASSWORD` environment variable.
-- `password_policy` `(string: "")` - The name of the
-  [password policy](https://developer.hashicorp.com/vault/docs/concepts/password-policies) to use when generating passwords
-  for this database. If not specified, this will use a default policy defined as:
-  20 characters with at least 1 uppercase, 1 lowercase, 1 number, and 1 dash character.
-- `tls` `(bool: false)` - Specifies whether to use TLS when connecting to Redis.
-- `ca_cert` `(string: optional)` - Specifies whether to use TLS when connecting to Redis.
-
-### Static Role Configuration (`role`)
-
-- `name` `(string: "my-static-role")` - Specifies the name of the role to create.
-- `db_name` `(string: "benchmark-redis-db")` - Specifies the name of the database connection to use for this role.
-- `rotation_period` `(string: "5m")` – Specifies the amount of time Vault should wait before rotating the password. The minimum is 5 seconds.
-- `username` `(string: <required>)` – Specifies the database username that this Vault role corresponds to. This can also be provided via the `VAULT_BENCHMARK_STATIC_REDIS_USERNAME` environment variable.
-- `insecure_tls` `(bool: false)` - Specifies whether to skip verification of the server certificate when using TLS. This can also be provided via the `VAULT_BENCHMARK_STATIC_REDIS_PASSWORD` environment variable.
-
 ## Example HCL
 
 ```hcl
@@ -72,3 +44,31 @@ Target: http://localhost:8200
 op                     count  rate         throughput   mean        95th%       99th%        successRatio
 redis_static_secret_1  4818   2408.666450  2404.376084  4.154177ms  4.843807ms  12.356863ms  100.00%
 ```
+
+## Benchmark Configuration Parameters
+
+### DB Configuration (`db_connection`)
+
+- `name` `(string: "benchmark-redis-db")` - Name for this database connection.
+- `plugin_name` `(string: "redis-database-plugin")` - Specifies the name of the plugin to use for this connection.
+- `plugin_version` `(string: "")` - Specifies the semantic version of the plugin to use for this connection.
+- `verify_connection` `(bool: true)` – Specifies if the connection is verified during initial configuration. Defaults to true.
+- `allowed_roles` `(list: ["my-*-role"])` - List of the roles allowed to use this connection.
+- `host` `(string: <required>)` - Specifies the host to connect to.
+- `port` `(int: <required>)` - Specifies the port to connect to.
+- `username` `(string: <required>)` - The root credential username. This can also be provided via the `VAULT_BENCHMARK_STATIC_REDIS_USERNAME` environment variable.
+- `password` `(string: <required>)` - The root credential password. This can also be provided via the `VAULT_BENCHMARK_STATIC_REDIS_PASSWORD` environment variable.
+- `password_policy` `(string: "")` - The name of the
+  [password policy](https://developer.hashicorp.com/vault/docs/concepts/password-policies) to use when generating passwords
+  for this database. If not specified, this will use a default policy defined as:
+  20 characters with at least 1 uppercase, 1 lowercase, 1 number, and 1 dash character.
+- `tls` `(bool: false)` - Specifies whether to use TLS when connecting to Redis.
+- `ca_cert` `(string: optional)` - Specifies whether to use TLS when connecting to Redis.
+
+### Static Role Configuration (`role`)
+
+- `name` `(string: "my-static-role")` - Specifies the name of the role to create.
+- `db_name` `(string: "benchmark-redis-db")` - Specifies the name of the database connection to use for this role.
+- `rotation_period` `(string: "5m")` – Specifies the amount of time Vault should wait before rotating the password. The minimum is 5 seconds.
+- `username` `(string: <required>)` – Specifies the database username that this Vault role corresponds to. This can also be provided via the `VAULT_BENCHMARK_STATIC_REDIS_USERNAME` environment variable.
+- `insecure_tls` `(bool: false)` - Specifies whether to skip verification of the server certificate when using TLS. This can also be provided via the `VAULT_BENCHMARK_STATIC_REDIS_PASSWORD` environment variable.

--- a/docs/tests/secret-ssh-issue.md
+++ b/docs/tests/secret-ssh-issue.md
@@ -2,6 +2,35 @@
 
 This benchmark tests the performance of Signed SSH Certificate issue operations.
 
+## Example Configuration
+
+```hcl
+test "ssh_issue" "ssh_issue_test1" {
+        weight = 100
+        config {
+                role {
+                        allow_user_certificates = true
+                }
+                issued_cert {
+                        key_type = "rsa"
+                        key_bits = 4096
+                }
+        }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+Setting up targets...
+Starting benchmarks. Will run for 5s...
+Benchmark complete!
+Target: http://127.0.0.1:8200
+op               count  rate      throughput  mean          95th%         99th%         successRatio
+ssh_issue_test1  27     5.362763  3.370474    2.282482814s  4.071793559s  4.143636093s  100.00%
+```
+
 ## Test Parameters
 
 ### Role Config `role`
@@ -234,32 +263,3 @@ This benchmark tests the performance of Signed SSH Certificate issue operations.
 
 - `extensions` `(map<string|string>: "")` – Specifies a map of the extensions
   that the certificate should be signed for. Defaults to none.
-
-## Example Configuration
-
-```hcl
-test "ssh_issue" "ssh_issue_test1" {
-        weight = 100
-        config {
-                role {
-                        allow_user_certificates = true
-                }
-                issued_cert {
-                        key_type = "rsa"
-                        key_bits = 4096
-                }
-        }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-Setting up targets...
-Starting benchmarks. Will run for 5s...
-Benchmark complete!
-Target: http://127.0.0.1:8200
-op               count  rate      throughput  mean          95th%         99th%         successRatio
-ssh_issue_test1  27     5.362763  3.370474    2.282482814s  4.071793559s  4.143636093s  100.00%
-```

--- a/docs/tests/secret-ssh-sign.md
+++ b/docs/tests/secret-ssh-sign.md
@@ -2,6 +2,36 @@
 
 This benchmark tests the performance of SSH key signing operations.
 
+## Example Configuration
+
+```hcl
+test "ssh_sign" "ssh_sign_test1" {
+  weight = 100
+  config {
+    role {
+      allow_user_certificates = true
+    }
+    key_signing {
+      ttl = "5m"
+    }
+  }
+}
+```
+
+Additional configuration examples can be found in the [ssh configuration directory](/example-configs/ssh/).
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+Setting up targets...
+Starting benchmarks. Will run for 5s...
+Benchmark complete!
+Target: http://127.0.0.1:8200
+op              count  rate        throughput  mean         95th%        99th%        successRatio
+ssh_sign_test1  4589   917.639190  915.430105  10.905496ms  13.797087ms  15.231341ms  100.00%
+```
+
 ## Test Parameters
 
 ### Role Config `role`
@@ -224,33 +254,3 @@ This benchmark tests the performance of SSH key signing operations.
 
 - `extensions` `(map<string|string>: "")` – Specifies a map of the extensions
   that the certificate should be signed for. Defaults to none.
-
-## Example Configuration
-
-```hcl
-test "ssh_sign" "ssh_sign_test1" {
-  weight = 100
-  config {
-    role {
-      allow_user_certificates = true
-    }
-    key_signing {
-      ttl = "5m"
-    }
-  }
-}
-```
-
-Additional configuration examples can be found in the [ssh configuration directory](/example-configs/ssh/).
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-Setting up targets...
-Starting benchmarks. Will run for 5s...
-Benchmark complete!
-Target: http://127.0.0.1:8200
-op              count  rate        throughput  mean         95th%        99th%        successRatio
-ssh_sign_test1  4589   917.639190  915.430105  10.905496ms  13.797087ms  15.231341ms  100.00%
-```

--- a/docs/tests/secret-transform-tokenization.md
+++ b/docs/tests/secret-transform-tokenization.md
@@ -2,6 +2,32 @@
 
 This benchmark will test Vault's Transform secrets engine by performing Tokenization encoding on provided input.
 
+### Example Configuration
+
+```hcl
+test "transform_tokenization" "tokenization_test1" {
+ weight = 100
+ config {
+  input {
+   ttl = "5s"
+            value = "123456789"
+  }
+ }
+}
+```
+
+## Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+Setting up targets...
+Starting benchmarks. Will run for 5s...
+Benchmark complete!
+Target: http://127.0.0.1:8200
+op                  count  rate         throughput   mean        95th%        99th%        successRatio
+tokenization_test1  7390   1477.682521  1474.223784  6.774487ms  12.870357ms  15.383365ms  100.00%
+```
+
 ## Test Parameters
 
 ### Role Config `role`
@@ -160,29 +186,3 @@ This benchmark will test Vault's Transform secrets engine by performing Tokeniza
     }
   ]
   ```
-
-### Example Configuration
-
-```hcl
-test "transform_tokenization" "tokenization_test1" {
- weight = 100
- config {
-  input {
-   ttl = "5s"
-            value = "123456789"
-  }
- }
-}
-```
-
-## Example Usage
-
-```bash
-$ vault-benchmark run -config=config.hcl
-Setting up targets...
-Starting benchmarks. Will run for 5s...
-Benchmark complete!
-Target: http://127.0.0.1:8200
-op                  count  rate         throughput   mean        95th%        99th%        successRatio
-tokenization_test1  7390   1477.682521  1474.223784  6.774487ms  12.870357ms  15.383365ms  100.00%
-```

--- a/docs/tests/secret-transit.md
+++ b/docs/tests/secret-transit.md
@@ -2,19 +2,6 @@
 
 This benchmark tests the performance of the transit operations.
 
-## Test Parameters
-
-### Transit Config
-
-- `convergent_encryption` _(bool: false)_: If enabled, the key will support convergent encryption, where the same plaintext creates the same ciphertext. This requires derived to be set to true. When enabled, each encryption(/decryption/rewrap/datakey) operation will derive a nonce value rather than randomly generate it.
-- `derived` _(bool: false)_: Specifies if key derivation is to be used. If enabled, all encrypt/decrypt requests to this named key must provide a context which is used for key derivation.
-- `type` _(string: "rsa-2048")_: Specifies the type of key to create.  See [API docs](https://developer.hashicorp.com/vault/api-docs/secret/transit#type) for supported values.
-- `payload_len` _(int: 128)_: Specifies the payload length to use for encryption/decryption operations.
-- `context_len` _(int: 32)_: Specifies the context length to use for encryption/decryption operations.
-- `hash_algorithm` _(string: "sha2-256")_:  Specifies the hash algorithm to use for supporting key types (notably, not including ed25519 which specifies its own hash algorithm).  See [API docs](https://developer.hashicorp.com/vault/api-docs/secret/transit#hash_algorithm) for supported values.
-- `signature_algorithm` _(string: "pss")_: When using a RSA key, specifies the RSA signature algorithm to use for signing.  See [API docs](https://developer.hashicorp.com/vault/api-docs/secret/transit#signature_algorithm) for supported values.
-- `marshaling_algorithm` _(string: "asn1")_: Specifies the way in which the signature should be marshaled. This currently only applies to ECDSA keys.  See [API docs](https://developer.hashicorp.com/vault/api-docs/secret/transit#marshaling_algorithm) for supported values.
-
 ## Example Configuration
 
 ```hcl
@@ -58,3 +45,16 @@ transit_encrypt_test_1  3570   1785.412839  1784.967498  609.48µs    1.17847ms 
 transit_sign_test_1     3509   1755.252455  1753.604967  2.257936ms  3.614323ms  5.015208ms  100.00%
 transit_verify_test_1   3453   1727.512538  1727.166507  615.155µs   1.183563ms  1.818366ms  100.00%
 ```
+
+## Test Parameters
+
+### Transit Config
+
+- `convergent_encryption` _(bool: false)_: If enabled, the key will support convergent encryption, where the same plaintext creates the same ciphertext. This requires derived to be set to true. When enabled, each encryption(/decryption/rewrap/datakey) operation will derive a nonce value rather than randomly generate it.
+- `derived` _(bool: false)_: Specifies if key derivation is to be used. If enabled, all encrypt/decrypt requests to this named key must provide a context which is used for key derivation.
+- `type` _(string: "rsa-2048")_: Specifies the type of key to create.  See [API docs](https://developer.hashicorp.com/vault/api-docs/secret/transit#type) for supported values.
+- `payload_len` _(int: 128)_: Specifies the payload length to use for encryption/decryption operations.
+- `context_len` _(int: 32)_: Specifies the context length to use for encryption/decryption operations.
+- `hash_algorithm` _(string: "sha2-256")_:  Specifies the hash algorithm to use for supporting key types (notably, not including ed25519 which specifies its own hash algorithm).  See [API docs](https://developer.hashicorp.com/vault/api-docs/secret/transit#hash_algorithm) for supported values.
+- `signature_algorithm` _(string: "pss")_: When using a RSA key, specifies the RSA signature algorithm to use for signing.  See [API docs](https://developer.hashicorp.com/vault/api-docs/secret/transit#signature_algorithm) for supported values.
+- `marshaling_algorithm` _(string: "asn1")_: Specifies the way in which the signature should be marshaled. This currently only applies to ECDSA keys.  See [API docs](https://developer.hashicorp.com/vault/api-docs/secret/transit#marshaling_algorithm) for supported values.


### PR DESCRIPTION
Move the example sections closer to the top as it's not immediately obvious to scroll clear to the bottom of the doc to see an example.