### PR TITLE
Add example PKI benchmark configurations

### DIFF
--- a/docs/examples/pki/leased/pki-ec-p256.hcl
+++ b/docs/examples/pki/leased/pki-ec-p256.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ec"
+            key_bits = "256"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ec"
+            key_bits = "256"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = true
+            key_type = "ec"
+            key_bits = "256"
+        }
+    }
+}

--- a/docs/examples/pki/leased/pki-ec-p384.hcl
+++ b/docs/examples/pki/leased/pki-ec-p384.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ec"
+            key_bits = "384"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ec"
+            key_bits = "384"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = true
+            key_type = "ec"
+            key_bits = "384"
+        }
+    }
+}

--- a/docs/examples/pki/leased/pki-ec-p521.hcl
+++ b/docs/examples/pki/leased/pki-ec-p521.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ec"
+            key_bits = "521"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ec"
+            key_bits = "521"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = true
+            key_type = "ec"
+            key_bits = "521"
+        }
+    }
+}

--- a/docs/examples/pki/leased/pki-ed25519.hcl
+++ b/docs/examples/pki/leased/pki-ed25519.hcl
@@ -1,0 +1,25 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ed25519"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ed25519"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = true
+            key_type = "ed25519"
+        }
+    }
+}

--- a/docs/examples/pki/leased/pki-rsa-2048.hcl
+++ b/docs/examples/pki/leased/pki-rsa-2048.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "rsa"
+            key_bits = "2048"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "rsa"
+            key_bits = "2048"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = true
+            key_type = "rsa"
+            key_bits = "2048"
+        }
+    }
+}

--- a/docs/examples/pki/leased/pki-rsa-3072.hcl
+++ b/docs/examples/pki/leased/pki-rsa-3072.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "rsa"
+            key_bits = "3072"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "rsa"
+            key_bits = "3072"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = true
+            key_type = "rsa"
+            key_bits = "3072"
+        }
+    }
+}

--- a/docs/examples/pki/leased/pki-rsa-4096.hcl
+++ b/docs/examples/pki/leased/pki-rsa-4096.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "rsa"
+            key_bits = "4096"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "rsa"
+            key_bits = "4096"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = true
+            key_type = "rsa"
+            key_bits = "4096"
+        }
+    }
+}

--- a/docs/examples/pki/not-stored/pki-ec-p256.hcl
+++ b/docs/examples/pki/not-stored/pki-ec-p256.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ec"
+            key_bits = "256"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ec"
+            key_bits = "256"
+        }
+        role {
+            ttl = "10s"
+            no_store = true
+            generate_lease = false
+            key_type = "ec"
+            key_bits = "256"
+        }
+    }
+}

--- a/docs/examples/pki/not-stored/pki-ec-p384.hcl
+++ b/docs/examples/pki/not-stored/pki-ec-p384.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ec"
+            key_bits = "384"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ec"
+            key_bits = "384"
+        }
+        role {
+            ttl = "10s"
+            no_store = true
+            generate_lease = false
+            key_type = "ec"
+            key_bits = "384"
+        }
+    }
+}

--- a/docs/examples/pki/not-stored/pki-ec-p521.hcl
+++ b/docs/examples/pki/not-stored/pki-ec-p521.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ec"
+            key_bits = "521"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ec"
+            key_bits = "521"
+        }
+        role {
+            ttl = "10s"
+            no_store = true
+            generate_lease = false
+            key_type = "ec"
+            key_bits = "521"
+        }
+    }
+}

--- a/docs/examples/pki/not-stored/pki-ed25519.hcl
+++ b/docs/examples/pki/not-stored/pki-ed25519.hcl
@@ -1,0 +1,25 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ed25519"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ed25519"
+        }
+        role {
+            ttl = "10s"
+            no_store = true
+            generate_lease = false
+            key_type = "ed25519"
+        }
+    }
+}

--- a/docs/examples/pki/not-stored/pki-rsa-2048.hcl
+++ b/docs/examples/pki/not-stored/pki-rsa-2048.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "rsa"
+            key_bits = "2048"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "rsa"
+            key_bits = "2048"
+        }
+        role {
+            ttl = "10s"
+            no_store = true
+            generate_lease = false
+            key_type = "rsa"
+            key_bits = "2048"
+        }
+    }
+}

--- a/docs/examples/pki/not-stored/pki-rsa-3072.hcl
+++ b/docs/examples/pki/not-stored/pki-rsa-3072.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "rsa"
+            key_bits = "3072"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "rsa"
+            key_bits = "3072"
+        }
+        role {
+            ttl = "10s"
+            no_store = true
+            generate_lease = false
+            key_type = "rsa"
+            key_bits = "3072"
+        }
+    }
+}

--- a/docs/examples/pki/not-stored/pki-rsa-4096.hcl
+++ b/docs/examples/pki/not-stored/pki-rsa-4096.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "rsa"
+            key_bits = "4096"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "rsa"
+            key_bits = "4096"
+        }
+        role {
+            ttl = "10s"
+            no_store = true
+            generate_lease = false
+            key_type = "rsa"
+            key_bits = "4096"
+        }
+    }
+}

--- a/docs/examples/pki/stored/pki-ec-p256.hcl
+++ b/docs/examples/pki/stored/pki-ec-p256.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ec"
+            key_bits = "256"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ec"
+            key_bits = "256"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = false
+            key_type = "ec"
+            key_bits = "256"
+        }
+    }
+}

--- a/docs/examples/pki/stored/pki-ec-p384.hcl
+++ b/docs/examples/pki/stored/pki-ec-p384.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ec"
+            key_bits = "384"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ec"
+            key_bits = "384"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = false
+            key_type = "ec"
+            key_bits = "384"
+        }
+    }
+}

--- a/docs/examples/pki/stored/pki-ec-p521.hcl
+++ b/docs/examples/pki/stored/pki-ec-p521.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ec"
+            key_bits = "521"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ec"
+            key_bits = "521"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = false
+            key_type = "ec"
+            key_bits = "521"
+        }
+    }
+}

--- a/docs/examples/pki/stored/pki-ed25519.hcl
+++ b/docs/examples/pki/stored/pki-ed25519.hcl
@@ -1,0 +1,25 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "ed25519"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "ed25519"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = false
+            key_type = "ed25519"
+        }
+    }
+}

--- a/docs/examples/pki/stored/pki-rsa-2048.hcl
+++ b/docs/examples/pki/stored/pki-rsa-2048.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "rsa"
+            key_bits = "2048"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "rsa"
+            key_bits = "2048"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = false
+            key_type = "rsa"
+            key_bits = "2048"
+        }
+    }
+}

--- a/docs/examples/pki/stored/pki-rsa-3072.hcl
+++ b/docs/examples/pki/stored/pki-rsa-3072.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "rsa"
+            key_bits = "3072"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "rsa"
+            key_bits = "3072"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = false
+            key_type = "rsa"
+            key_bits = "3072"
+        }
+    }
+}

--- a/docs/examples/pki/stored/pki-rsa-4096.hcl
+++ b/docs/examples/pki/stored/pki-rsa-4096.hcl
@@ -1,0 +1,28 @@
+vault_addr = "http://127.0.0.1:8200"
+vault_token = "root"
+vault_namespace="root"
+duration = "30s"
+
+test "pki_issue" "pki_issue" {
+    weight = 100
+    config {
+        setup_delay="2s"
+        root_ca {
+            common_name = "benchmark.test Root Authority"
+            key_type = "rsa"
+            key_bits = "4096"
+        }
+        intermediate_csr {
+            common_name = "benchmark.test Intermediate Authority"
+            key_type = "rsa"
+            key_bits = "4096"
+        }
+        role {
+            ttl = "10s"
+            no_store = false
+            generate_lease = false
+            key_type = "rsa"
+            key_bits = "4096"
+        }
+    }
+}


### PR DESCRIPTION
Adds stored/non-stored/leased configurations for all homogeneous (root/int/leaf) key types (rsa/ec/ed25519). 