### PR TITLE
Fix KVv2 write action

### DIFF
--- a/benchmarktests/target_secret_kvv2.go
+++ b/benchmarktests/target_secret_kvv2.go
@@ -177,6 +177,7 @@ func (k *KVV2Test) Setup(client *api.Client, randomMountName bool, mountName str
 		numKVs:     k.config.NumKVs,
 		kvSize:     k.config.KVSize,
 		logger:     k.logger,
+		action:     k.action,
 	}, nil
 }
 


### PR DESCRIPTION
The `action` field wasn't set, so when `Target` or `TargetInfo` was called the code would hit the default case and do a kvv2 read, even if the configuration specified a kvv2 write:
```go
func (k *KVV2Test) Target(client *api.Client) vegeta.Target {
	switch k.action {
	case "write":
		return k.write(client)
	default:
		return k.read(client)
	}
}

func (k *KVV2Test) GetTargetInfo() TargetInfo {
	var method string
	switch k.action {
	case "write":
		method = KVV2WriteTestMethod
	default:
		method = KVV2ReadTestMethod
	}
	return TargetInfo{
		method:     method,
		pathPrefix: k.pathPrefix,
	}
}

```