### PR TITLE
Add disable HTTP/2 flag

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -362,7 +362,8 @@ func (r *RunCommand) Run(args []string) int {
 			return 1
 		}
 
-		// Check if we're forcing HTTP/1.1
+		// Check if we're forcing HTTP/1.1. Used to make sure benchmark traffic
+		// is spread across nodes when Vault is behind a load balancer.
 		if conf.DisableHTTP2 {
 			benchmarkLogger.Warn("http2 disabled, using http/1.1")
 			transport := cfg.HttpClient.Transport.(*http.Transport)

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type VaultBenchmarkCoreConfig struct {
 	ClusterJSON    string                            `hcl:"cluster_json,optional"`
 	CAPEMFile      string                            `hcl:"ca_pem_file,optional"`
 	PPROFInterval  string                            `hcl:"pprof_interval,optional"`
+	LogLevel       string                            `hcl:"log_level,optional"`
 	Tests          []*benchmarktests.BenchmarkTarget `hcl:"test,block"`
 	RPS            int                               `hcl:"rps,optional"`
 	Workers        int                               `hcl:"workers,optional"`
@@ -42,7 +43,7 @@ type VaultBenchmarkCoreConfig struct {
 	InputResults   bool                              `hcl:"input_results,optional"`
 	Cleanup        bool                              `hcl:"cleanup,optional"`
 	Debug          bool                              `hcl:"debug,optional"`
-	LogLevel       string                            `hcl:"log_level,optional"`
+	DisableHTTP2   bool                              `hcl:"disable_http2,optional"`
 }
 
 func NewVaultBenchmarkCoreConfig() *VaultBenchmarkCoreConfig {


### PR DESCRIPTION
When benchmarking Vault behind a load balancer, vault-benchmark will unequally send traffic to a given node due to HTTP/2 connection multiplexing. This PR adds a flag to disable HTTP/2 and force HTTP/1.1 on the Vault client used during the benchmark.