### PR TITLE
add gcp secrets engine target

### DIFF
--- a/benchmarktests/target_auth_gcp.go
+++ b/benchmarktests/target_auth_gcp.go
@@ -8,10 +8,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -157,7 +157,7 @@ func (g *GCPAuth) Setup(client *api.Client, mountName string, topLevelConfig *To
 	// check if the provided argument should be read from file
 	creds := g.config.GCPAuthConfig.Credentials
 	if len(creds) > 0 && creds[0] == '@' {
-		contents, err := ioutil.ReadFile(creds[1:])
+		contents, err := os.ReadFile(creds[1:])
 		if err != nil {
 			return nil, fmt.Errorf("error reading file: %w", err)
 		}

--- a/benchmarktests/target_secret_gcp.go
+++ b/benchmarktests/target_secret_gcp.go
@@ -207,4 +207,4 @@ func (g *GCPTest) Setup(client *api.Client, randomMountName bool, mountName stri
 	}, nil
 }
 
-func (a *GCPTest) Flags(fs *flag.FlagSet) {}
+func (g *GCPTest) Flags(fs *flag.FlagSet) {}

--- a/benchmarktests/target_secret_gcp.go
+++ b/benchmarktests/target_secret_gcp.go
@@ -125,12 +125,12 @@ func (g *GCPTest) GetTargetInfo() TargetInfo {
 	}
 }
 
-func (g *GCPTest) Setup(client *api.Client, randomMountName bool, mountName string) (BenchmarkBuilder, error) {
-	g.logger = targetLogger.Named(GCPSecretTestType)
-
+func (g *GCPTest) Setup(client *api.Client, mountName string, topLevelConfig *TopLevelTargetConfig) (BenchmarkBuilder, error) {
+	var err error
 	secretPath := mountName
-	if randomMountName {
-		var err error
+	g.logger = targetLogger.Named(RedisDynamicSecretTestType)
+
+	if topLevelConfig.RandomMounts {
 		secretPath, err = uuid.GenerateUUID()
 		if err != nil {
 			log.Fatalf("can't create UUID")
@@ -141,7 +141,7 @@ func (g *GCPTest) Setup(client *api.Client, randomMountName bool, mountName stri
 	g.logger.Trace(mountLogMessage("secrets", "gcp", secretPath))
 	setupLogger := g.logger.Named(secretPath)
 
-	err := client.Sys().Mount(secretPath, &api.MountInput{
+	err = client.Sys().Mount(secretPath, &api.MountInput{
 		Type: "gcp",
 	})
 	if err != nil {

--- a/benchmarktests/target_secret_gcp.go
+++ b/benchmarktests/target_secret_gcp.go
@@ -1,0 +1,210 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmarktests
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/vault/api"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+)
+
+// Constants for test
+const (
+	GCPSecretTestType     = "gcp_secret"
+	GCPSecretTestMethod   = "GET"
+	GCPSecretCredentials  = VaultBenchmarkEnvVarPrefix + "GCP_CREDENTIALS"
+	GCPSecretBindings     = VaultBenchmarkEnvVarPrefix + "GCP_BINDINGS"
+	GCPAccessTokenType    = "access_token"
+	GCPServiceAccountType = "service_account_key"
+)
+
+func init() {
+	// "Register" this test to the main test registry
+	TestList[GCPSecretTestType] = func() BenchmarkBuilder { return &GCPTest{} }
+}
+
+type GCPTest struct {
+	pathPrefix string
+	header     http.Header
+	roleName   string
+	config     *GCPSecretTestConfig
+	logger     hclog.Logger
+}
+
+type GCPSecretTestConfig struct {
+	GCPConfig  *GCPSecretConfig  `hcl:"gcp,block"`
+	GCPRoleset *GCPSecretRoleset `hcl:"roleset,block"`
+}
+
+type GCPSecretConfig struct {
+	Credentials string `hcl:"credentials,optional"`
+	TTL         string `hcl:"ttl,optional"`
+	MaxTTL      string `hcl:"max_ttl,optional"`
+}
+
+type GCPSecretRoleset struct {
+	Name        string   `hcl:"name,optional"`
+	SecretType  string   `hcl:"secret_type,optional"`
+	Project     string   `hcl:"project"`
+	Bindings    string   `hcl:"bindings,optional"`
+	TokenScopes []string `hcl:"token_scopes,optional"`
+}
+
+func (g *GCPTest) ParseConfig(body hcl.Body) error {
+	testConfig := &struct {
+		Config *GCPSecretTestConfig `hcl:"config,block"`
+	}{
+		Config: &GCPSecretTestConfig{
+			GCPConfig:  &GCPSecretConfig{Credentials: os.Getenv(GCPSecretCredentials)},
+			GCPRoleset: &GCPSecretRoleset{Name: "benchmark-roleset", SecretType: GCPAccessTokenType, Bindings: os.Getenv(GCPSecretBindings)},
+		},
+	}
+
+	diags := gohcl.DecodeBody(body, nil, testConfig)
+	if diags.HasErrors() {
+		return fmt.Errorf("error decoding to struct: %v", diags)
+	}
+	g.config = testConfig.Config
+
+	if g.config.GCPRoleset.Project == "" {
+		return fmt.Errorf("GCP project is required")
+	}
+
+	if g.config.GCPRoleset.Bindings == "" {
+		return fmt.Errorf("GCP bindings are required")
+	}
+
+	if g.config.GCPConfig.Credentials == "" {
+		return fmt.Errorf("GCP Credentials are required")
+	}
+
+	return nil
+}
+
+func (g *GCPTest) Target(client *api.Client) vegeta.Target {
+	var url string
+
+	if g.config.GCPRoleset.SecretType == GCPAccessTokenType {
+		url = client.Address() + g.pathPrefix + "/roleset/" + g.roleName + "/token"
+	} else if g.config.GCPRoleset.SecretType == GCPServiceAccountType {
+		url = client.Address() + g.pathPrefix + "/roleset/" + g.roleName + "/key"
+	}
+
+	return vegeta.Target{
+		Method: "GET",
+		URL:    url,
+		Header: g.header,
+	}
+}
+
+func (g *GCPTest) Cleanup(client *api.Client) error {
+	g.logger.Trace(cleanupLogMessage(g.pathPrefix))
+	_, err := client.Logical().Delete(strings.Replace(g.pathPrefix, "/v1/", "/sys/mounts/", 1))
+	if err != nil {
+		return fmt.Errorf("error cleaning up mount: %v", err)
+	}
+	return nil
+}
+
+func (g *GCPTest) GetTargetInfo() TargetInfo {
+	return TargetInfo{
+		method:     GCPSecretTestMethod,
+		pathPrefix: g.pathPrefix,
+	}
+}
+
+func (g *GCPTest) Setup(client *api.Client, randomMountName bool, mountName string) (BenchmarkBuilder, error) {
+	g.logger = targetLogger.Named(GCPSecretTestType)
+
+	secretPath := mountName
+	if randomMountName {
+		var err error
+		secretPath, err = uuid.GenerateUUID()
+		if err != nil {
+			log.Fatalf("can't create UUID")
+		}
+	}
+
+	config := g.config
+	g.logger.Trace(mountLogMessage("secrets", "gcp", secretPath))
+	setupLogger := g.logger.Named(secretPath)
+
+	err := client.Sys().Mount(secretPath, &api.MountInput{
+		Type: "gcp",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error mounting gcp: %v", err)
+	}
+
+	// check if the credentials argument should be read from file
+	creds := config.GCPConfig.Credentials
+	if len(creds) > 0 && creds[0] == '@' {
+		contents, err := ioutil.ReadFile(creds[1:])
+		if err != nil {
+			return nil, fmt.Errorf("error reading credentials file: %w", err)
+		}
+
+		config.GCPConfig.Credentials = string(contents)
+	}
+
+	// check if the bindings argument should be read from file
+	bindings := config.GCPRoleset.Bindings
+	if len(bindings) > 0 && bindings[0] == '@' {
+		contents, err := ioutil.ReadFile(bindings[1:])
+		if err != nil {
+			return nil, fmt.Errorf("error reading bindings file: %w", err)
+		}
+
+		config.GCPRoleset.Bindings = string(contents)
+	}
+
+	// Encode GCP Config
+	setupLogger.Trace(parsingConfigLogMessage("gcp"))
+	gcpConfigData, err := structToMap(config.GCPConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing gcp config from struct: %v", err)
+	}
+
+	// Write GCP config
+	setupLogger.Trace(writingLogMessage("gcp config"))
+	_, err = client.Logical().Write(secretPath+"/config", gcpConfigData)
+	if err != nil {
+		return nil, fmt.Errorf("error writing gcp config: %v", err)
+	}
+
+	// Decode Role Config
+	setupLogger.Trace(parsingConfigLogMessage("role"))
+	gcpRolesetData, err := structToMap(config.GCPRoleset)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing roleset config from struct: %v", err)
+	}
+
+	// Create Role
+	setupLogger.Trace(writingLogMessage("gcp roleset"), "name", config.GCPRoleset.Name)
+	_, err = client.Logical().Write(secretPath+"/roleset/"+config.GCPRoleset.Name, gcpRolesetData)
+	if err != nil {
+		return nil, fmt.Errorf("error writing gcp roleset: %v", err)
+	}
+
+	return &GCPTest{
+		pathPrefix: "/v1/" + secretPath,
+		header:     generateHeader(client),
+		roleName:   config.GCPRoleset.Name,
+		logger:     g.logger,
+		config:     g.config,
+	}, nil
+}
+
+func (a *GCPTest) Flags(fs *flag.FlagSet) {}

--- a/benchmarktests/target_secret_gcp.go
+++ b/benchmarktests/target_secret_gcp.go
@@ -6,7 +6,6 @@ package benchmarktests
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -151,7 +150,7 @@ func (g *GCPTest) Setup(client *api.Client, mountName string, topLevelConfig *To
 	// check if the credentials argument should be read from file
 	creds := config.GCPConfig.Credentials
 	if len(creds) > 0 && creds[0] == '@' {
-		contents, err := ioutil.ReadFile(creds[1:])
+		contents, err := os.ReadFile(creds[1:])
 		if err != nil {
 			return nil, fmt.Errorf("error reading credentials file: %w", err)
 		}
@@ -162,7 +161,7 @@ func (g *GCPTest) Setup(client *api.Client, mountName string, topLevelConfig *To
 	// check if the bindings argument should be read from file
 	bindings := config.GCPRoleset.Bindings
 	if len(bindings) > 0 && bindings[0] == '@' {
-		contents, err := ioutil.ReadFile(bindings[1:])
+		contents, err := os.ReadFile(bindings[1:])
 		if err != nil {
 			return nil, fmt.Errorf("error reading bindings file: %w", err)
 		}

--- a/docs/tests/secret-azure.md
+++ b/docs/tests/secret-azure.md
@@ -1,4 +1,4 @@
-# Azure Authentication Benchmark (`azure_auth`)
+# Azure Secrets Engine Benchmark (`azure_secret`)
 This benchmark will test the dynamic generation of Azure credentials.
 
 ## Benchmark Configuration Parameters

--- a/docs/tests/secret-gcp.md
+++ b/docs/tests/secret-gcp.md
@@ -31,7 +31,7 @@ test "gcp_secret" "gcp_secret1" {
 
     roleset {
       name    = "gcp-secrets-roleset"
-      project = "hc-5a8eb1bf5cb84ac28a118b4f59a"
+      project = "<project_id>"
       bindings = "@gcpbindings.hcl" 
       token_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
     }

--- a/docs/tests/secret-gcp.md
+++ b/docs/tests/secret-gcp.md
@@ -57,7 +57,7 @@ test "gcp_secret" "gcp_secret1" {
   weight = 100
   config {
     gcp {
-    //   credentials = "@VaultServiceAccountKeyNew.json"
+    credentials = "@VaultServiceAccountKey.json"
     }
 
     roleset {

--- a/docs/tests/secret-gcp.md
+++ b/docs/tests/secret-gcp.md
@@ -1,0 +1,82 @@
+# GCP Secrets Engine Benchmark (`gcp_secret`)
+This benchmark will test the dynamic generation of GCP access token and service account key credentials.
+
+## Benchmark Configuration Parameters
+
+### GCP Configuration (`config`)
+- `credentials` (`string: <required>`) - JSON credentials (either file contents or '@path/to/file')
+  See docs for [alternative ways](https://developer.hashicorp.com/vault/docs/secrets/gcp#setup) to pass in to this parameter, as well as the
+  [required permissions](https://developer.hashicorp.com/vault/docs/secrets/gcp#required-permissions). This value can also be provided with the `VAULT_BENCHMARK_GCP_CREDENTIALS` environment variable. 
+- `ttl` (`string:"0s"`) – Specifies default config TTL for long-lived credentials
+  (i.e. service account keys). Uses [duration format strings](https://developer.hashicorp.com/vault/docs/concepts/duration-format).
+- `max_ttl` (`string:"0s"`)– Specifies the maximum config TTL for long-lived credentials
+  (i.e. service account keys). Uses [duration format strings](https://developer.hashicorp.com/vault/docs/concepts/duration-format).
+
+### GCP Roleset (`roleset`)
+- `name` (`string: "benchmark-roleset"`): Name of the role.
+- `secret_type` (`string: "access_token"`): Type of secret generated for this role set. Accepted values: `access_token`, `service_account_key`. 
+- `project` (`string: <required>`): Name of the GCP project that this roleset's service account will belong to. 
+- `bindings` (`string: <required>`): Bindings configuration string (expects HCL or JSON format in raw or base64-encoded string). This value can also be provided with the `VAULT_BENCHMARK_GCP_BINDINGS` environment variable. 
+- `token_scopes` (`array: []`): List of OAuth scopes to assign to `access_token` secrets generated under this role set (`access_token` role sets only)
+
+## Example HCL
+## Example Usage (generating an oauth2 access token)
+```hcl
+test "gcp_secret" "gcp_secret1" {
+  weight = 100
+  config {
+    gcp {
+      credentials = "@VaultServiceAccountKeyNew.json"
+    }
+
+    roleset {
+      name    = "gcp-secrets-roleset"
+      project = "hc-5a8eb1bf5cb84ac28a118b4f59a"
+      bindings = "@gcpbindings.hcl" 
+      token_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+    }
+  }
+}
+```
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-07-31T09:30:59.723-0500 [INFO]  vault-benchmark: setting up targets
+2023-07-31T09:31:02.290-0500 [INFO]  vault-benchmark: starting benchmarks: duration=10s
+2023-07-31T09:31:12.364-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://localhost:8200
+op           count  rate        throughput  mean         95th%        99th%       successRatio
+gcp_secret1  3647   364.508644  362.029238  27.450306ms  39.522725ms  88.93587ms  100.00%
+```
+
+## Example Usage (generating a service account key)
+```
+rps = "1"
+
+test "gcp_secret" "gcp_secret1" {
+  weight = 100
+  config {
+    gcp {
+    //   credentials = "@VaultServiceAccountKeyNew.json"
+    }
+
+    roleset {
+      name    = "gcp-secrets-roleset"
+      project = "hc-5a8eb1bf5cb84ac28a118b4f59a"
+      secret_type = "service_account_key"
+      bindings = "@gcpbindings.hcl" 
+    //   token_scopes = ["access_token"]
+    }
+  }
+}
+```
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-07-31T09:32:16.964-0500 [INFO]  vault-benchmark: setting up targets
+2023-07-31T09:32:18.896-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-07-31T09:32:21.503-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://localhost:8200
+op           count  rate      throughput  mean          95th%         99th%         successRatio
+gcp_secret1  2      1.999662  1.246645    559.547125ms  604.136792ms  604.136792ms  100.00%
+```

--- a/docs/tests/secret-gcp.md
+++ b/docs/tests/secret-gcp.md
@@ -62,7 +62,7 @@ test "gcp_secret" "gcp_secret1" {
 
     roleset {
       name    = "gcp-secrets-roleset"
-      project = "<project-id""
+      project = "<project-id>"
       secret_type = "service_account_key"
       bindings = "@gcpbindings.hcl" 
       token_scopes = ["access_token"]

--- a/docs/tests/secret-gcp.md
+++ b/docs/tests/secret-gcp.md
@@ -57,15 +57,15 @@ test "gcp_secret" "gcp_secret1" {
   weight = 100
   config {
     gcp {
-    credentials = "@VaultServiceAccountKey.json"
+       credentials = "@VaultServiceAccountKey.json"
     }
 
     roleset {
       name    = "gcp-secrets-roleset"
-      project = "hc-5a8eb1bf5cb84ac28a118b4f59a"
+      project = "<project-id""
       secret_type = "service_account_key"
       bindings = "@gcpbindings.hcl" 
-    //   token_scopes = ["access_token"]
+      token_scopes = ["access_token"]
     }
   }
 }

--- a/docs/tests/secret-gcp.md
+++ b/docs/tests/secret-gcp.md
@@ -26,7 +26,7 @@ test "gcp_secret" "gcp_secret1" {
   weight = 100
   config {
     gcp {
-      credentials = "@VaultServiceAccountKeyNew.json"
+      credentials = "@VaultServiceAccountKey.json"
     }
 
     roleset {


### PR DESCRIPTION
Tests gcp secrets engine for creation of both access tokens and secret account keys. 