### PR TITLE
Add gcp impersonations secrets engine

### DIFF
--- a/benchmarktests/target_secret_gcp_impersonation.go
+++ b/benchmarktests/target_secret_gcp_impersonation.go
@@ -102,12 +102,12 @@ func (g *GCPImpersonationTest) GetTargetInfo() TargetInfo {
 	}
 }
 
-func (g *GCPImpersonationTest) Setup(client *api.Client, randomMountName bool, mountName string) (BenchmarkBuilder, error) {
-	g.logger = targetLogger.Named(GCPImpersonationSecretTestType)
-
+func (g *GCPImpersonationTest) Setup(client *api.Client, mountName string, topLevelConfig *TopLevelTargetConfig) (BenchmarkBuilder, error) {
+	var err error
 	secretPath := mountName
-	if randomMountName {
-		var err error
+	g.logger = targetLogger.Named(RedisDynamicSecretTestType)
+
+	if topLevelConfig.RandomMounts {
 		secretPath, err = uuid.GenerateUUID()
 		if err != nil {
 			log.Fatalf("can't create UUID")
@@ -118,7 +118,7 @@ func (g *GCPImpersonationTest) Setup(client *api.Client, randomMountName bool, m
 	g.logger.Trace(mountLogMessage("secrets", "gcp_impersonation", secretPath))
 	setupLogger := g.logger.Named(secretPath)
 
-	err := client.Sys().Mount(secretPath, &api.MountInput{
+	err = client.Sys().Mount(secretPath, &api.MountInput{
 		Type: "gcp",
 	})
 	if err != nil {

--- a/benchmarktests/target_secret_gcp_impersonation.go
+++ b/benchmarktests/target_secret_gcp_impersonation.go
@@ -105,7 +105,7 @@ func (g *GCPImpersonationTest) GetTargetInfo() TargetInfo {
 func (g *GCPImpersonationTest) Setup(client *api.Client, mountName string, topLevelConfig *TopLevelTargetConfig) (BenchmarkBuilder, error) {
 	var err error
 	secretPath := mountName
-	g.logger = targetLogger.Named(RedisDynamicSecretTestType)
+	g.logger = targetLogger.Named(GCPImpersonationSecretTestType)
 
 	if topLevelConfig.RandomMounts {
 		secretPath, err = uuid.GenerateUUID()

--- a/benchmarktests/target_secret_gcp_impersonation.go
+++ b/benchmarktests/target_secret_gcp_impersonation.go
@@ -1,0 +1,175 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmarktests
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/vault/api"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+)
+
+// Constants for test
+const (
+	GCPImpersonationSecretTestType            = "gcp_impersonation_secret"
+	GCPImpersonationSecretTestMethod          = "GET"
+	GCPImpersonationSecretServiceAccountEmail = VaultBenchmarkEnvVarPrefix + "GCP_SERVICE_ACCOUNT_EMAIL"
+)
+
+func init() {
+	// "Register" this test to the main test registry
+	TestList[GCPImpersonationSecretTestType] = func() BenchmarkBuilder { return &GCPImpersonationTest{} }
+}
+
+type GCPImpersonationTest struct {
+	pathPrefix string
+	header     http.Header
+	config     *GCPImpersonationSecretTestConfig
+	logger     hclog.Logger
+}
+
+type GCPImpersonationSecretTestConfig struct {
+	GCPConfig      *GCPSecretConfig `hcl:"gcp,block"`
+	GCPImpersonate *GCPImpersonate  `hcl:"impersonate,block"`
+}
+
+type GCPImpersonate struct {
+	Name                string   `hcl:"name,optional"`
+	ServiceAccountEmail string   `hcl:"service_account_email,optional"`
+	TTL                 string   `hcl:"ttl,optional"`
+	TokenScopes         []string `hcl:"token_scopes,optional"`
+}
+
+func (g *GCPImpersonationTest) ParseConfig(body hcl.Body) error {
+	testConfig := &struct {
+		Config *GCPImpersonationSecretTestConfig `hcl:"config,block"`
+	}{
+		Config: &GCPImpersonationSecretTestConfig{
+			GCPConfig:      &GCPSecretConfig{Credentials: os.Getenv(GCPSecretCredentials)},
+			GCPImpersonate: &GCPImpersonate{Name: "benchmark-gcp-impersonation", ServiceAccountEmail: os.Getenv(GCPImpersonationSecretServiceAccountEmail)},
+		},
+	}
+
+	diags := gohcl.DecodeBody(body, nil, testConfig)
+	if diags.HasErrors() {
+		return fmt.Errorf("error decoding to struct: %v", diags)
+	}
+	g.config = testConfig.Config
+
+	if g.config.GCPImpersonate.ServiceAccountEmail == "" {
+		return fmt.Errorf("GCP Service Account Email is required")
+	}
+
+	if g.config.GCPConfig.Credentials == "" {
+		return fmt.Errorf("GCP Credentials are required")
+	}
+
+	return nil
+}
+
+func (g *GCPImpersonationTest) Target(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: "GET",
+		URL:    client.Address() + g.pathPrefix + "/impersonated-account/" + g.config.GCPImpersonate.Name,
+		Header: g.header,
+	}
+}
+
+func (g *GCPImpersonationTest) Cleanup(client *api.Client) error {
+	g.logger.Trace(cleanupLogMessage(g.pathPrefix))
+	_, err := client.Logical().Delete(strings.Replace(g.pathPrefix, "/v1/", "/sys/mounts/", 1))
+	if err != nil {
+		return fmt.Errorf("error cleaning up gcp impersonation mount: %v", err)
+	}
+	return nil
+}
+
+func (g *GCPImpersonationTest) GetTargetInfo() TargetInfo {
+	return TargetInfo{
+		method:     GCPImpersonationSecretTestMethod,
+		pathPrefix: g.pathPrefix,
+	}
+}
+
+func (g *GCPImpersonationTest) Setup(client *api.Client, randomMountName bool, mountName string) (BenchmarkBuilder, error) {
+	g.logger = targetLogger.Named(GCPImpersonationSecretTestType)
+
+	secretPath := mountName
+	if randomMountName {
+		var err error
+		secretPath, err = uuid.GenerateUUID()
+		if err != nil {
+			log.Fatalf("can't create UUID")
+		}
+	}
+
+	config := g.config
+	g.logger.Trace(mountLogMessage("secrets", "gcp_impersonation", secretPath))
+	setupLogger := g.logger.Named(secretPath)
+
+	err := client.Sys().Mount(secretPath, &api.MountInput{
+		Type: "gcp",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error mounting gcp: %v", err)
+	}
+
+	// check if the credentials argument should be read from file
+	creds := config.GCPConfig.Credentials
+	if len(creds) > 0 && creds[0] == '@' {
+		contents, err := ioutil.ReadFile(creds[1:])
+		if err != nil {
+			return nil, fmt.Errorf("error reading credentials file: %w", err)
+		}
+
+		config.GCPConfig.Credentials = string(contents)
+	}
+
+	// Encode GCP Config
+	setupLogger.Trace(parsingConfigLogMessage("gcp impersonation"))
+	gcpImpersonationConfigData, err := structToMap(config.GCPConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing gcp config from struct: %v", err)
+	}
+
+	// Write GCP config
+	setupLogger.Trace(writingLogMessage("gcp impersonation config"))
+	_, err = client.Logical().Write(secretPath+"/config", gcpImpersonationConfigData)
+	if err != nil {
+		return nil, fmt.Errorf("error writing gcp config: %v", err)
+	}
+
+	// Decode Role Config
+	setupLogger.Trace(parsingConfigLogMessage("gcp impersonation"))
+	gcpImpersonationData, err := structToMap(config.GCPImpersonate)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing gcp impersonation config from struct: %v", err)
+	}
+
+	// Create Role
+	setupLogger.Trace(writingLogMessage("gcp impersonation"), "name", config.GCPImpersonate.Name)
+	_, err = client.Logical().Write(secretPath+"/impersonated-account/"+config.GCPImpersonate.Name, gcpImpersonationData)
+	if err != nil {
+		return nil, fmt.Errorf("error writing gcp impersonation: %v", err)
+	}
+
+	return &GCPImpersonationTest{
+		pathPrefix: "/v1/" + secretPath,
+		header:     generateHeader(client),
+		logger:     g.logger,
+		config:     g.config,
+	}, nil
+}
+
+func (a *GCPImpersonationTest) Flags(fs *flag.FlagSet) {}

--- a/docs/tests/secret-impersonate-gcp.md
+++ b/docs/tests/secret-impersonate-gcp.md
@@ -64,7 +64,7 @@ test "gcp_secret" "gcp_secret1" {
 
     roleset {
       name    = "gcp-secrets-roleset"
-      project = "hc-5a8eb1bf5cb84ac28a118b4f59a"
+      project = "<project-id>"
       secret_type = "service_account_key"
       bindings = "@gcpbindings.hcl" 
     //   token_scopes = ["access_token"]

--- a/docs/tests/secret-impersonate-gcp.md
+++ b/docs/tests/secret-impersonate-gcp.md
@@ -59,7 +59,7 @@ test "gcp_secret" "gcp_secret1" {
   weight = 100
   config {
     gcp {
-    //   credentials = "@VaultServiceAccountKeyNew.json"
+      credentials = "@VaultServiceAccountKeyNew.json"
     }
 
     roleset {
@@ -67,7 +67,7 @@ test "gcp_secret" "gcp_secret1" {
       project = "<project-id>"
       secret_type = "service_account_key"
       bindings = "@gcpbindings.hcl" 
-    //   token_scopes = ["access_token"]
+      token_scopes = ["access_token"]
     }
   }
 }

--- a/docs/tests/secret-impersonate-gcp.md
+++ b/docs/tests/secret-impersonate-gcp.md
@@ -1,0 +1,84 @@
+# GCP Secrets Engine Benchmark (`gcp_secret`)
+This benchmark will test the creation of a unique OAuth token for an impersonated GCP service account.
+
+## Benchmark Configuration Parameters
+
+### GCP Impersonation Configuration (`config`)
+- `credentials` (`string: <required>`) - JSON credentials (either file contents or '@path/to/file')
+  See docs for [alternative ways](https://developer.hashicorp.com/vault/docs/secrets/gcp#setup) to pass in to this parameter, as well as the
+  [required permissions](https://developer.hashicorp.com/vault/docs/secrets/gcp#required-permissions). This value can also be provided with the `VAULT_BENCHMARK_GCP_CREDENTIALS` environment variable. 
+- `ttl` (`string:"0s"`) – Specifies default config TTL for long-lived credentials
+  (i.e. service account keys). Uses [duration format strings](https://developer.hashicorp.com/vault/docs/concepts/duration-format).
+- `max_ttl` (`string:"0s"`)– Specifies the maximum config TTL for long-lived credentials
+  (i.e. service account keys). Uses [duration format strings](https://developer.hashicorp.com/vault/docs/concepts/duration-format).
+
+### GCP Impersonation (`impersonate`)
+- `name` (`string: "benchmark-gcp-impersonation"`): Name of the impersonated account. Cannot be updated.
+- `service_account_email` (`string: <required>`): Email of the GCP service account to
+  manage. Cannot be updated. This value can also be provided with the `VAULT_BENCHMARK_GCP_SERVICE_ACCOUNT_EMAIL` environment variable. 
+- `token_scopes` (`array: []`): List of OAuth scopes to assign to access tokens
+  generated under this impersonation account.
+- `ttl` (`duration: ""`): Lifetime of the token generated. Defaults to 1 hour and
+  is limited to a maximum of 12 hours. Uses [duration format strings](https://developer.hashicorp.com/vault/docs/concepts/duration-format).
+
+
+## Example HCL
+## Example Usage (generating an oauth2 access token)
+```hcl
+test "gcp_impersonation_secret" "gcp_secret1" {
+  weight = 100
+  config {
+    gcp {
+      credentials = "@/accountkey.json"
+    }
+
+    impersonate {
+      name                  = "benchmark-impersonate"
+      service_account_email = "service_account@.iam.gserviceaccount.com"
+      token_scopes = ["https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/compute"]
+    }
+  }
+}
+```
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-08-04T11:40:05.274-0500 [INFO]  vault-benchmark: setting up targets
+2023-08-04T11:40:05.757-0500 [INFO]  vault-benchmark: starting benchmarks: duration=10s
+2023-08-04T11:40:15.762-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://127.0.0.1:8200
+op           count  rate      throughput  mean        95th%       99th%       successRatio
+gcp_secret1  10     1.111245  1.110902    3.851262ms  6.247583ms  6.247583ms  100.00%
+```
+
+## Example Usage (generating a service account key)
+```
+rps = "1"
+
+test "gcp_secret" "gcp_secret1" {
+  weight = 100
+  config {
+    gcp {
+    //   credentials = "@VaultServiceAccountKeyNew.json"
+    }
+
+    roleset {
+      name    = "gcp-secrets-roleset"
+      project = "hc-5a8eb1bf5cb84ac28a118b4f59a"
+      secret_type = "service_account_key"
+      bindings = "@gcpbindings.hcl" 
+    //   token_scopes = ["access_token"]
+    }
+  }
+}
+```
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-07-31T09:32:16.964-0500 [INFO]  vault-benchmark: setting up targets
+2023-07-31T09:32:18.896-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-07-31T09:32:21.503-0500 [INFO]  vault-benchmark: benchmark complete
+Target: http://localhost:8200
+op           count  rate      throughput  mean          95th%         99th%         successRatio
+gcp_secret1  2      1.999662  1.246645    559.547125ms  604.136792ms  604.136792ms  100.00%
+```

--- a/docs/tests/secret-impersonate-gcp.md
+++ b/docs/tests/secret-impersonate-gcp.md
@@ -50,35 +50,3 @@ Target: http://127.0.0.1:8200
 op           count  rate      throughput  mean        95th%       99th%       successRatio
 gcp_secret1  10     1.111245  1.110902    3.851262ms  6.247583ms  6.247583ms  100.00%
 ```
-
-## Example Usage (generating a service account key)
-```
-rps = "1"
-
-test "gcp_secret" "gcp_secret1" {
-  weight = 100
-  config {
-    gcp {
-      credentials = "@VaultServiceAccountKeyNew.json"
-    }
-
-    roleset {
-      name    = "gcp-secrets-roleset"
-      project = "<project-id>"
-      secret_type = "service_account_key"
-      bindings = "@gcpbindings.hcl" 
-      token_scopes = ["access_token"]
-    }
-  }
-}
-```
-
-```bash
-$ vault-benchmark run -config=config.hcl
-2023-07-31T09:32:16.964-0500 [INFO]  vault-benchmark: setting up targets
-2023-07-31T09:32:18.896-0500 [INFO]  vault-benchmark: starting benchmarks: duration=2s
-2023-07-31T09:32:21.503-0500 [INFO]  vault-benchmark: benchmark complete
-Target: http://localhost:8200
-op           count  rate      throughput  mean          95th%         99th%         successRatio
-gcp_secret1  2      1.999662  1.246645    559.547125ms  604.136792ms  604.136792ms  100.00%
-```


### PR DESCRIPTION
Support gcp impersonated accounts: https://developer.hashicorp.com/vault/docs/secrets/gcp#impersonated-accounts