### PR TITLE
Add Docker Compose File

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ docker run \
   -e VAULT_ADDR="http://localhost:8200" \
   -e VAULT_DEV_LISTEN_ADDRESS="0.0.0.0:8200" \
   --privileged \
-  --detach vault:latest
+  --detach hashicorp/vault:latest
 
 docker logs -f vault
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ test "kvv2_write" "static_secret_writes" {
 }
 ```
 This test configuration will run two different benchmark tests, an `approle_auth` test, and a `kvv2_write` test, with the percentage of requests being split evenly between the two.
- 
+
 Then we run the binary and provide the configuration file path:
 ```bash
 $ vault-benchmark run -config=config.hcl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 services:
   vault:
     image: hashicorp/vault:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.7"
+services:
+  vault:
+    image: hashicorp/vault:latest
+    container_name: vault
+    ports:
+      - "8200:8200"
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: "root"
+      VAULT_ADDR: "http://localhost:8200"
+      VAULT_DEV_LISTEN_ADDRESS : "vault:8200"
+    privileged: true
+
+  vault-benchmark:
+    image: hashicorp/vault-benchmark:latest
+    container_name: vault-benchmark
+    hostname: vault-benchmark
+    volumes:
+      - ./configs/:/opt/vault-benchmark/configs
+    command: ["vault-benchmark", "run", "-config", "/opt/vault-benchmark/configs/config.hcl"]
+    depends_on:
+      - vault


### PR DESCRIPTION
Adds a sample docker compose file that can be used to spin up docker containers for Vault and Vault Benchmark.  

Also a minor update to point to the correct repo for Vault