### PR TITLE
Add MongoDB Atlas Secret Engine Tests

### DIFF
--- a/benchmarktests/target_secret_mongodb_atlas.go
+++ b/benchmarktests/target_secret_mongodb_atlas.go
@@ -1,0 +1,189 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmarktests
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/vault/api"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+)
+
+const (
+	MongoDBAtlasSecretTestType   = "mongodb_atlas_secret"
+	MongoDBAtlasSecretTestMethod = "GET"
+	MongoDBAtlasPublicKey        = VaultBenchmarkEnvVarPrefix + "MONGODB_ATLAS_PUBLIC_KEY"
+	MongoDBAtlasPrivateKey       = VaultBenchmarkEnvVarPrefix + "MONGODB_ATLAS_PRIVATE_KEY"
+)
+
+func init() {
+	// "Register" this test to the main test registry
+	TestList[MongoDBAtlasSecretTestType] = func() BenchmarkBuilder { return &MongoDBAtlasTest{} }
+}
+
+type MongoDBAtlasTest struct {
+	pathPrefix string
+	header     http.Header
+	roleName   string
+	config     *MongoDBAtlasSecretTestConfig
+	logger     hclog.Logger
+}
+
+type MongoDBAtlasSecretTestConfig struct {
+	MongoDBAtlasConfig     *MongoDBAtlasConfig     `hcl:"db_connection,block"`
+	MongoDBAtlasRoleConfig *MongoDBAtlasRoleConfig `hcl:"role,block"`
+}
+
+type MongoDBAtlasConfig struct {
+	Name             string   `hcl:"name,optional"`
+	PluginName       string   `hcl:"plugin_name,optional"`
+	PluginVersion    string   `hcl:"plugin_version,optional"`
+	VerifyConnection *bool    `hcl:"verify_connection"`
+	AllowedRoles     []string `hcl:"allowed_roles,optional"`
+	PublicKey        string   `hcl:"public_key,optional"`
+	PrivateKey       string   `hcl:"private_key,optional"`
+	ProjectID        string   `hcl:"project_id,optional"`
+	UsernameTemplate string   `hcl:"username_template,optional"`
+}
+
+type MongoDBAtlasRoleConfig struct {
+	Name               string `hcl:"name,optional"`
+	DBName             string `hcl:"db_name,optional"`
+	DefaultTTL         string `hcl:"default_ttl,optional"`
+	MaxTTL             string `hcl:"max_ttl,optional"`
+	CreationStatements string `hcl:"creation_statements,optional"`
+}
+
+func (m *MongoDBAtlasTest) ParseConfig(body hcl.Body) error {
+	testConfig := &struct {
+		Config *MongoDBAtlasSecretTestConfig `hcl:"config,block"`
+	}{
+		Config: &MongoDBAtlasSecretTestConfig{
+			MongoDBAtlasConfig: &MongoDBAtlasConfig{
+				Name:         "benchmark-mongodb-atlas",
+				PluginName:   "mongodbatlas-database-plugin",
+				AllowedRoles: []string{"benchmark-role"},
+				PublicKey:    os.Getenv(MongoDBAtlasPublicKey),
+				PrivateKey:   os.Getenv(MongoDBAtlasPrivateKey),
+			},
+			MongoDBAtlasRoleConfig: &MongoDBAtlasRoleConfig{
+				Name:               "benchmark-role",
+				DBName:             "benchmark-mongodb-atlas",
+				DefaultTTL:         "1h",
+				MaxTTL:             "24h",
+				CreationStatements: `{"database_name": "admin","roles": [{"databaseName":"admin","roleName":"atlasAdmin"}]}`,
+			},
+		},
+	}
+
+	diags := gohcl.DecodeBody(body, nil, testConfig)
+	if diags.HasErrors() {
+		return fmt.Errorf("error decoding to struct: %v", diags)
+	}
+	m.config = testConfig.Config
+
+	// Ensure that the username and password are set
+	if m.config.MongoDBAtlasConfig.PublicKey == "" {
+		return fmt.Errorf("no mongodb_atlas PublicKey provided but required")
+	}
+
+	if m.config.MongoDBAtlasConfig.PrivateKey == "" {
+		return fmt.Errorf("no mongodb_atlas PrivateKey provided but required")
+	}
+
+	return nil
+}
+
+func (m *MongoDBAtlasTest) Target(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: "GET",
+		URL:    client.Address() + m.pathPrefix + "/creds/" + m.roleName,
+		Header: m.header,
+	}
+}
+
+func (m *MongoDBAtlasTest) Cleanup(client *api.Client) error {
+	m.logger.Trace(cleanupLogMessage(m.pathPrefix))
+	_, err := client.Logical().Delete(strings.Replace(m.pathPrefix, "/v1/", "/sys/mounts/", 1))
+	if err != nil {
+		return fmt.Errorf("error cleaning up mount: %v", err)
+	}
+	return nil
+}
+
+func (m *MongoDBAtlasTest) GetTargetInfo() TargetInfo {
+	return TargetInfo{
+		method:     MongoDBAtlasSecretTestMethod,
+		pathPrefix: m.pathPrefix,
+	}
+}
+
+func (m *MongoDBAtlasTest) Setup(client *api.Client, mountName string, topLevelConfig *TopLevelTargetConfig) (BenchmarkBuilder, error) {
+	var err error
+	secretPath := mountName
+	m.logger = targetLogger.Named(MongoDBAtlasSecretTestType)
+
+	if topLevelConfig.RandomMounts {
+		secretPath, err = uuid.GenerateUUID()
+		if err != nil {
+			log.Fatalf("can't create UUID")
+		}
+	}
+
+	m.logger.Trace(mountLogMessage("secrets", "database", secretPath))
+	err = client.Sys().Mount(secretPath, &api.MountInput{
+		Type: "database",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error mounting db secrets engine: %v", err)
+	}
+
+	setupLogger := m.logger.Named(secretPath)
+
+	// Decode DB Config
+	setupLogger.Trace(parsingConfigLogMessage("db"))
+	dbConfigData, err := structToMap(m.config.MongoDBAtlasConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding mongodb_atlas config from struct: %v", err)
+	}
+
+	// Write DB config
+	setupLogger.Trace(writingLogMessage("mongodb_atlas config"), "name", m.config.MongoDBAtlasConfig.Name)
+	_, err = client.Logical().Write(secretPath+"/config/"+m.config.MongoDBAtlasConfig.Name, dbConfigData)
+	if err != nil {
+		return nil, fmt.Errorf("error writing db config: %v", err)
+	}
+
+	// Decode Role Config
+	setupLogger.Trace(parsingConfigLogMessage("role"))
+	roleConfigData, err := structToMap(m.config.MongoDBAtlasRoleConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing role config from struct: %v", err)
+	}
+
+	// Create Role
+	setupLogger.Trace(writingLogMessage("mongodb_atlas role"), "name", m.config.MongoDBAtlasRoleConfig.Name)
+	_, err = client.Logical().Write(secretPath+"/roles/"+m.config.MongoDBAtlasRoleConfig.Name, roleConfigData)
+	if err != nil {
+		return nil, fmt.Errorf("error writing mongodb_atlas role %q: %v", m.config.MongoDBAtlasRoleConfig.Name, err)
+	}
+
+	return &MongoDBAtlasTest{
+		pathPrefix: "/v1/" + secretPath,
+		header:     generateHeader(client),
+		roleName:   m.config.MongoDBAtlasRoleConfig.Name,
+		logger:     m.logger,
+	}, nil
+}
+
+func (m *MongoDBAtlasTest) Flags(fs *flag.FlagSet) {}

--- a/docs/tests/secret-mongodb-atlas.md
+++ b/docs/tests/secret-mongodb-atlas.md
@@ -1,0 +1,70 @@
+# MongoDB Atlas Secrets Engine Benchmark
+
+This benchmark will test the dynamic generation of MongoDB Atlas credentials.
+
+## Test Parameters
+
+### MongoDB Atlas Database Configuration `db_connection`
+
+- `name` `(string: "benchmark-mongodb-atlas")` – Specifies the name for this database
+  connection. This is specified as part of the URL.
+- `plugin_name` `(string: mongodbatlas-database-plugin)` - Specifies the name of the plugin to use
+  for this connection.
+- `plugin_version` `(string: "")` - Specifies the semantic version of the plugin to use for this connection.
+- `verify_connection` `(bool: true)` – Specifies if the connection is verified
+  during initial configuration. Defaults to true.
+- `allowed_roles` `(list: [])` - List of the roles allowed to use this connection.
+  Defaults to empty (no roles), if contains a `*` any role can use this connection.
+- `public_key` `(string: <required>)` – The Public Programmatic API Key used to authenticate with the MongoDB Atlas API. This can also be provided via the `VAULT_BENCHMARK_MONGODB_ATLAS_PUBLIC_KEY` environment variable.
+- `private_key` `(string: <required>)` - The Private Programmatic API Key used to connect with MongoDB Atlas API. This can also be provided via the `VAULT_BENCHMARK_MONGODB_ATLAS_PRIVATE_KEY` environment variable.
+- `project_id` `(string: <required>)` - The [Project ID](https://www.mongodb.com/docs/atlas/api/#project-id) the Database User should be created within.
+- `username_template` `(string)` - Template describing how dynamic usernames are generated.
+
+### Role Config
+
+- `name` `(string: "benchmark-role")` – Specifies the name of the role to create. This
+  is specified as part of the URL.
+- `db_name` `(string: "benchmark-mongo")` - The name of the database connection to use
+  for this role.
+- `default_ttl` `(string: "")` - Specifies the TTL for the leases
+  associated with this role. Accepts time suffixed strings (`1h`) or an integer
+  number of seconds. Defaults to system/engine default TTL time.
+- `max_ttl` `(string: "")` - Specifies the maximum TTL for the leases
+  associated with this role. Accepts time suffixed strings (`1h`) or an integer
+  number of seconds. Defaults to `sys/mounts`'s default TTL time; this value is allowed to be less than the mount max TTL (or, if not set, the system max TTL), but it is not allowed to be longer. See also [The TTL General Case](https://developer.hashicorp.com/vault/docs/concepts/tokens#the-general-case).
+- `creation_statements` `(string)` – Specifies the database
+  statements executed to create and configure a user. Must be a
+  serialized JSON object, or a base64-encoded serialized JSON object.
+  The object can optionally contain a `database_name`, the name of
+  the authentication database to log into MongoDB. In Atlas deployments of
+  MongoDB, the options for the authentication database include admin (default) and $external database.
+  The object must also contain a `roles` array, and from Vault version 1.6.0 (plugin
+  version 0.2.0) may optionally contain a `scopes` array. The `roles` array
+  contains objects that hold a series of roles `roleName`, an optional
+
+## Example Configuration
+
+```hcl
+test "mongodb_atlas_secret" "mongodb_atlas_secret_test_1" {
+    weight = 100
+    config {
+        db_connection {
+            public_key = "PUBILC_KEY"
+            private_key = "PRIVATE_KEY"
+            project_id = "PROJECT_ID"
+        }
+    }
+}
+```
+
+### Example Usage
+
+```bash
+$ vault-benchmark run -config=config.hcl
+2023-08-14T12:52:45.035-0400 [INFO]  vault-benchmark: setting up targets
+2023-08-14T12:52:45.040-0400 [INFO]  vault-benchmark: starting benchmarks: duration=2s
+2023-08-14T12:52:49.222-0400 [INFO]  vault-benchmark: benchmark complete
+Target: http://127.0.0.1:8200
+op                           count  rate      throughput  mean          95th%         99th%         successRatio
+mongodb_atlas_secret_test_1  21     9.873511  5.021741    1.618011815s  2.137313314s  2.152995625s  100.00%
+```


### PR DESCRIPTION
Adds tests for MongoDB Atlas

You will need to have a sandbox account set up in order to test this.

How to find the private/public keys can be found in [this doc](https://www.mongodb.com/docs/atlas/configure-api-access/#grant-programmatic-access-to-an-organization)