### PR TITLE
Correct block names

### DIFF
--- a/benchmarktests/target_secret_mongo.go
+++ b/benchmarktests/target_secret_mongo.go
@@ -70,7 +70,7 @@ type MongoDBRoleConfig struct {
 
 func (m *MongoDBTest) ParseConfig(body hcl.Body) error {
 	testConfig := &struct {
-		Config *MongoDBSecretTestConfig `hcl:"mongodb_secret,block"`
+		Config *MongoDBSecretTestConfig `hcl:"config,block"`
 	}{
 		Config: &MongoDBSecretTestConfig{
 			MongoDBConfig: &MongoDBConfig{

--- a/benchmarktests/target_secret_pki_sign.go
+++ b/benchmarktests/target_secret_pki_sign.go
@@ -232,7 +232,7 @@ type pkiSignRoleConfig struct {
 
 func (p *PKISignTest) ParseConfig(body hcl.Body) error {
 	testConfig := &struct {
-		Config *pkiSecretIssueTestConfig `hcl:"pki_sign,block"`
+		Config *pkiSecretIssueTestConfig `hcl:"config,block"`
 	}{
 		Config: &pkiSecretIssueTestConfig{
 			SetupDelay: "1s",

--- a/benchmarktests/target_secret_postgres.go
+++ b/benchmarktests/target_secret_postgres.go
@@ -86,7 +86,7 @@ type PostgreSQLRoleConfig struct {
 func (s *PostgreSQLSecret) ParseConfig(body hcl.Body) error {
 	// provide defaults
 	testConfig := &struct {
-		Config *PostgreSQLSecretTestConfig `hcl:"postgresql_secret,block"`
+		Config *PostgreSQLSecretTestConfig `hcl:"config,block"`
 	}{
 		Config: &PostgreSQLSecretTestConfig{
 			PostgreSQLDBConfig: &PostgreSQLDBConfig{

--- a/benchmarktests/target_secret_rabbitmq.go
+++ b/benchmarktests/target_secret_rabbitmq.go
@@ -64,7 +64,7 @@ type RabbitMQRoleConfig struct {
 
 func (r *RabbitMQTest) ParseConfig(body hcl.Body) error {
 	testConfig := &struct {
-		Config *RabbitMQSecretTestConfig `hcl:"rabbitmq_secret,block"`
+		Config *RabbitMQSecretTestConfig `hcl:"config,block"`
 	}{
 		Config: &RabbitMQSecretTestConfig{
 			RabbitMQConnectionConfig: &RabbitMQConnectionConfig{


### PR DESCRIPTION
All block names should start with `config`