### PR TITLE
Add postgres dockertests

### DIFF
--- a/helper/dockertest/postgres.go
+++ b/helper/dockertest/postgres.go
@@ -28,7 +28,6 @@ func CreatePostgresContainer(t *testing.T) (func(), string) {
 	}
 
 	runner, err := dockhelper.NewServiceRunner(runOpts)
-
 	if err != nil {
 		t.Fatalf("Error starting docker client for postgres: %s", err)
 	}

--- a/helper/dockertest/postgres.go
+++ b/helper/dockertest/postgres.go
@@ -33,7 +33,6 @@ func CreatePostgresContainer(t *testing.T) (func(), string) {
 	}
 
 	svc, err := runner.Start(ctx, true, false)
-
 	if err != nil {
 		t.Fatalf("Error starting postgres container: %s", err)
 	}

--- a/helper/dockertest/postgres.go
+++ b/helper/dockertest/postgres.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dockertest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	dockhelper "github.com/hashicorp/vault/sdk/helper/docker"
+)
+
+const (
+	postgresImageRepo = "postgres"
+	postgresImageTag  = "latest"
+)
+
+func CreatePostgresContainer(t *testing.T) (func(), string) {
+	ctx := context.Background()
+
+	runOpts := dockhelper.RunOptions{
+		ContainerName: "postgres",
+		ImageRepo:     postgresImageRepo,
+		ImageTag:      postgresImageTag,
+		Env:           []string{"POSTGRES_USER=username", "POSTGRES_PASSWORD=password"},
+		Ports:         []string{"5432/tcp"},
+	}
+
+	runner, err := dockhelper.NewServiceRunner(runOpts)
+
+	if err != nil {
+		t.Fatalf("Error starting docker client for postgres: %s", err)
+	}
+
+	svc, err := runner.Start(ctx, true, false)
+
+	if err != nil {
+		t.Fatalf("Error starting postgres container: %s", err)
+	}
+
+	var netName string
+	for netName = range svc.Container.NetworkSettings.Networks {
+		// Networks above is a map; we just need to find the first and
+		// only key of this map (network name). The range handles this
+		// for us, but we need a loop construction in order to use range.
+	}
+
+	containerIPAddress := svc.Container.NetworkSettings.Networks[netName].IPAddress
+
+	cleanup := func() {
+		err := runner.DockerAPI.ContainerRemove(ctx, svc.Container.ID, types.ContainerRemoveOptions{Force: true})
+		if err != nil {
+			t.Fatalf("Error removing postgres container: %s", err)
+		}
+	}
+
+	return cleanup, containerIPAddress
+}

--- a/test-fixtures/configs/invalid_postgres.hcl
+++ b/test-fixtures/configs/invalid_postgres.hcl
@@ -1,0 +1,21 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+duration      = "2s"
+report_mode   = "terse"
+random_mounts = true
+
+test "postgresql_secret" "postgres_test_1" {
+    weight = 100
+    config {
+        db_connection {
+            connection_url = "postgresql://username:password@<container_addr>:5432/postgres"
+            username = "username"
+            password = "invalid_password"
+        }
+
+        role {
+            creation_statements = "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";"
+        }
+    }
+}

--- a/test-fixtures/configs/postgres.hcl
+++ b/test-fixtures/configs/postgres.hcl
@@ -1,0 +1,21 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+duration      = "2s"
+report_mode   = "terse"
+random_mounts = true
+
+test "postgresql_secret" "postgres_test_1" {
+    weight = 100
+    config {
+        db_connection {
+            connection_url = "postgresql://username:password@<container_addr>:5432/postgres"
+            username = "username"
+            password = "password"
+        }
+
+        role {
+            creation_statements = "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";"
+        }
+    }
+}

--- a/test-fixtures/target_secret_postgres_test.go
+++ b/test-fixtures/target_secret_postgres_test.go
@@ -1,0 +1,61 @@
+package dockertest
+
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/vault-benchmark/helper/dockertest"
+	"github.com/hashicorp/vault-benchmark/helper/dockertest/dockerjobs"
+)
+
+func TestPostgres_Secret_Docker(t *testing.T) {
+	t.Parallel()
+
+	// Create Vault Container
+	vaultCleanup, vaultContainerIPAddress := dockertest.CreateVaultContainer(t)
+	defer vaultCleanup()
+
+	// Create Postgres Container
+	postgresCleanup, postgresContainerIPAddress := dockertest.CreatePostgresContainer(t)
+	defer postgresCleanup()
+
+	cleanupHCL, newHCLFile := editHCL(t, "./configs/postgres.hcl", "<container_addr>", postgresContainerIPAddress)
+	defer cleanupHCL()
+
+	// Run Vault-Benchmark Container
+	vaultAddr := fmt.Sprintf("http://%s:8200", vaultContainerIPAddress)
+	benchmarkCleanup, exitCode := dockerjobs.CreateVaultBenchmarkContainer(t, vaultAddr, "root", filepath.Base(newHCLFile))
+	defer benchmarkCleanup()
+
+	if exitCode != 0 {
+		t.Fatalf("Unexpected error code: %v", exitCode)
+	}
+}
+
+func TestPostgres_Invalid_Secret_Docker(t *testing.T) {
+	t.Parallel()
+
+	// Create Vault Container
+	vaultCleanup, vaultContainerIPAddress := dockertest.CreateVaultContainer(t)
+	defer vaultCleanup()
+
+	// Create Postgres Container
+	postgresCleanup, postgresContainerIPAddress := dockertest.CreatePostgresContainer(t)
+	defer postgresCleanup()
+
+	cleanupHCL, newHCLFile := editHCL(t, "./configs/invalid_postgres.hcl", "<container_addr>", postgresContainerIPAddress)
+	defer cleanupHCL()
+
+	// Run Vault-Benchmark Container
+	vaultAddr := fmt.Sprintf("http://%s:8200", vaultContainerIPAddress)
+	benchmarkCleanup, exitCode := dockerjobs.CreateVaultBenchmarkContainer(t, vaultAddr, "root", filepath.Base(newHCLFile))
+	defer benchmarkCleanup()
+
+	if exitCode != 0 {
+		t.Fatalf("Unexpected error code: %v", exitCode)
+	}
+}

--- a/test-fixtures/util.go
+++ b/test-fixtures/util.go
@@ -1,0 +1,40 @@
+package dockertest
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+)
+
+func editHCL(t *testing.T, file string, existing string, replace string) (func(), string) {
+	input, err := os.ReadFile(file)
+	if err != nil {
+		t.Errorf("unable to read file (%s): %s", file, err.Error())
+	}
+
+	output := bytes.Replace(input, []byte(existing), []byte(replace), -1)
+
+	i := len(file) - 4
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Error("error generating UUID")
+	}
+
+	modifiedFileName := fmt.Sprintf("%s_%s_modified_%s", file[:i], uuid, file[i:])
+	if err = os.WriteFile(modifiedFileName, output, 0666); err != nil {
+		t.Errorf("unable to write (%s): %s", modifiedFileName, err.Error())
+	}
+
+	// add defer cleanup of old file
+	cleanup := func() {
+		err := os.Remove(modifiedFileName)
+		if err != nil {
+			t.Fatalf("Error removing file (%s): %s", modifiedFileName, err)
+		}
+	}
+
+	return cleanup, modifiedFileName
+}

--- a/test-fixtures/util.go
+++ b/test-fixtures/util.go
@@ -28,7 +28,7 @@ func editHCL(t *testing.T, file string, existing string, replace string) (func()
 		t.Errorf("unable to write (%s): %s", modifiedFileName, err.Error())
 	}
 
-	// add defer cleanup of old file
+	// cleanup of modified file
 	cleanup := func() {
 		err := os.Remove(modifiedFileName)
 		if err != nil {


### PR DESCRIPTION
This test creates one vault and one postgres container. Then it creates a short lived benchmark container to run benchmark container tests against postgres. 

I'd love feedback on this part: https://github.com/hashicorp/vault-benchmark/pull/156/files#diff-a2919a4efaf14852c3c69c047c884889767b189da1d5de8729e120539f08ff32R50. To summarize, the test creates a postgres container, returns the IP address of the container then creates a new postgres HCL file that includes the postgres ip address. 