### PR TITLE
Fix deletion/rollback ldif errors in doc

### DIFF
--- a/docs/tests/secret-ldap-dynamic.md
+++ b/docs/tests/secret-ldap-dynamic.md
@@ -44,8 +44,8 @@ test "ldap_dynamic_secret" "ldap_secret_test1" {
         }
         role  {
             creation_ldif = "ZG46IGNuPXt7LlVzZXJuYW1lfX0sb3U9dXNlcnMsZGM9aGFzaGljb3JwLGRjPWNvbQpvYmplY3RDbGFzczogcGVyc29uCm9iamVjdENsYXNzOiB0b3AKY246IGxlYXJuCnNuOiB7ey5QYXNzd29yZCB8IHV0ZjE2bGUgfCBiYXNlNjR9fQptZW1iZXJPZjogY249ZGV2LG91PWdyb3VwcyxkYz1oYXNoaWNvcnAsZGM9Y29tCnVzZXJQYXNzd29yZDoge3suUGFzc3dvcmR9fQo="
-            deletion_ldif = "ZG46IGNuPXt7LlVzZXJuYW1lfX0sb3U9dXNlcnMsZGM9bGVhcm4sZGM9ZXhhbXBsZQpjaGFuZ2V0eXBlOiBkZWxldGUK"
-            rollback_ldif = "ZG46IGNuPXt7LlVzZXJuYW1lfX0sb3U9dXNlcnMsZGM9bGVhcm4sZGM9ZXhhbXBsZQpjaGFuZ2V0eXBlOiBkZWxldGUK"
+            deletion_ldif = "ZG46IGNuPXt7LlVzZXJuYW1lfX0sb3U9dXNlcnMsZGM9aGFzaGljb3JwLGRjPWNvbQpjaGFuZ2V0eXBlOiBkZWxldGUK"
+            rollback_ldif = "ZG46IGNuPXt7LlVzZXJuYW1lfX0sb3U9dXNlcnMsZGM9aGFzaGljb3JwLGRjPWNvbQpjaGFuZ2V0eXBlOiBkZWxldGUK"
         }
     }
 }


### PR DESCRIPTION
The user DN is incorrect for the `deletion_ldif` and `rollback_ldif` supplied in the doc.

Users are created in `ou=users,dc=hashicorp,dc=com`:
```bash
echo "ZG46IGNuPXt7LlVzZXJuYW1lfX0sb3U9dXNlcnMsZGM9aGFzaGljb3JwLGRjPWNvbQpvYmplY3RDbGFzczogcGVyc29uCm9iamVjdENsYXNzOiB0b3AKY246IGxlYXJuCnNuOiB7ey5QYXNzd29yZCB8IHV0ZjE2bGUgfCBiYXNlNjR9fQptZW1iZXJPZjogY249ZGV2LG91PWdyb3VwcyxkYz1oYXNoaWNvcnAsZGM9Y29tCnVzZXJQYXNzd29yZDoge3suUGFzc3dvcmR9fQo=" | base64 -d
dn: cn={{.Username}},ou=users,dc=hashicorp,dc=com
objectClass: person
objectClass: top
cn: learn
sn: {{.Password | utf16le | base64}}
memberOf: cn=dev,ou=groups,dc=hashicorp,dc=com
userPassword: {{.Password}}
```

But deletion/rollback points to `ou=users,dc=learn,dc=example`:
```
echo "ZG46IGNuPXt7LlVzZXJuYW1lfX0sb3U9dXNlcnMsZGM9bGVhcm4sZGM9ZXhhbXBsZQpjaGFuZ2V0eXBlOiBkZWxldGUK" | base64 -d
dn: cn={{.Username}},ou=users,dc=learn,dc=example
changetype: delete
```