### PR TITLE
Strip docs from generated file links

### DIFF
--- a/.github/scripts/generate-index-markdown.sh
+++ b/.github/scripts/generate-index-markdown.sh
@@ -12,6 +12,11 @@ extract_title() {
     echo "$title"
 }
 
+# Strip "docs/" from the file path
+strip_docs() {
+    echo "$1" | sed -E "s/^docs\///"
+}
+
 # Function to generate the list of benchmark tests
 generate_tests_list() {
     auth_tests_list=""
@@ -19,8 +24,9 @@ generate_tests_list() {
     system_tests_list=""
     for test_file in $(ls -1 docs/tests/* | sort); do
         if [[ -f "$test_file" ]]; then
+            test_file_link=$(strip_docs "$test_file")
             test_name=$(basename "$test_file")
-            test_link="[$(extract_title "$test_file")]($test_file)"
+            test_link="[$(extract_title "$test_file")]($test_file_link)"
             if [[ "$test_name" == *"auth"* ]]; then
                 auth_tests_list+="\n- $test_link"
             elif [[ "$test_name" == *"secret"* ]]; then

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 # Global vault-benchmark config options
 
-vault_addr = \"<http://127.0.0.1:8200\>"
+vault_addr = \"<http://127.0.0.1:8200>\"
 vault_token = \"root\"
 vault_namespace=\"root\"
 duration = \"2s\"
@@ -40,48 +40,49 @@ Below is a list of all currently available benchmark tests
 
 ### Auth Benchmark Tests
 
-- [Approle Authentication Benchmark (`approle_auth`)](docs/tests/auth-approle.md)
-- [AWS Authentication Credential Benchmark (`aws_auth`)](docs/tests/auth-aws.md)
-- [Azure Authentication Credential Benchmark (`azure_auth`)](docs/tests/auth-azure.md)
-- [Certification Authentication Benchmark (`cert_auth`)](docs/tests/auth-certificate.md)
-- [Google Cloud Platform Auth Benchmark (`gcp_auth`)](docs/tests/auth-gcp.md)
-- [GitHub Auth Benchmark (`github_auth`)](docs/tests/auth-github.md)
-- [JWT Static Credential Benchmark (`jwt_auth`)](docs/tests/auth-jwt.md)
-- [Kubernetes Auth Benchmark](docs/tests/auth-k8s.md)
-- [LDAP Auth Benchmark (`ldap_auth`)](docs/tests/auth-ldap.md)
-- [Userpass Auth Benchmark (`userpass_auth`)](docs/tests/auth-userpass.md)
+- [Approle Authentication Benchmark (`approle_auth`)](tests/auth-approle.md)
+- [AWS Authentication Credential Benchmark (`aws_auth`)](tests/auth-aws.md)
+- [Azure Authentication Credential Benchmark (`azure_auth`)](tests/auth-azure.md)
+- [Certification Authentication Benchmark (`cert_auth`)](tests/auth-certificate.md)
+- [Google Cloud Platform Auth Benchmark (`gcp_auth`)](tests/auth-gcp.md)
+- [GitHub Auth Benchmark (`github_auth`)](tests/auth-github.md)
+- [JWT Static Credential Benchmark (`jwt_auth`)](tests/auth-jwt.md)
+- [Kubernetes Auth Benchmark](tests/auth-k8s.md)
+- [LDAP Auth Benchmark (`ldap_auth`)](tests/auth-ldap.md)
+- [Userpass Auth Benchmark (`userpass_auth`)](tests/auth-userpass.md)
 
 ### Secret Benchmark Tests
 
-- [AWS Secrets Engine Benchmark (`aws_secret`)](docs/tests/secret-aws.md)
-- [Azure Secrets Engine Benchmark (`azure_secret`)](docs/tests/secret-azure.md)
-- [Cassandra Secrets Engine Benchmark (`cassandra_secret`)](docs/tests/secret-cassandra.md)
-- [Consul Secret Benchmark (`consul_secret`)](docs/tests/secret-consul.md)
-- [Couchbase Secrets Engine Benchmark (`couchbase_secret`)](docs/tests/secret-couchbase.md)
-- [Elasticsearch Secrets Engine Benchmark (`elasticsearch_secret`)](docs/tests/secret-elasticsearch.md)
-- [GCP Secrets Engine Benchmark (`gcp_secret`)](docs/tests/secret-gcp.md)
-- [GCP Secrets Engine Benchmark (`gcp_secret`)](docs/tests/secret-impersonate-gcp.md)
-- [KVV1 and KVV2 Secret Benchmark](docs/tests/secret-kv.md)
-- [LDAP Dynamic Secret Benchmark `ldap_dynamic_secret`](docs/tests/secret-ldap-dynamic.md)
-- [LDAP Static Secret Benchmark `ldap_static_secret`](docs/tests/secret-ldap-static.md)
-- [MongoDB Secrets Engine Benchmark](docs/tests/secret-mongo.md)
-- [MSSQL Secret Benchmark (`mssql_secret`)](docs/tests/secret-mssql.md)
-- [MySQL Secret Benchmark `mysql_secret`](docs/tests/secret-mysql.md)
-- [Nomad Secrets Engine Benchmark](docs/tests/secret-nomad.md)
-- [PKI Secret Configuration Options](docs/tests/secret-pki-issue.md)
-- [PKI Sign Secret Configuration Options](docs/tests/secret-pki-sign.md)
-- [Postgresql Secrets Engine Benchmark `postgresql_secret`](docs/tests/secret-postgresql.md)
-- [RabbitMQ Secret Configuration Options](docs/tests/secret-rabbit.md)
-- [Redis Dynamic Credential Benchmark (`redis_dynamic_secret`)](docs/tests/secret-redis-dynamic.md)
-- [Redis Static Credential Benchmark (`redis_static_secret`)](docs/tests/secret-redis-static.md)
-- [Signed SSH Secret Issue Configuration Options](docs/tests/secret-ssh-issue.md)
-- [SSH Key Signing Configuration Options](docs/tests/secret-ssh-sign.md)
-- [Transform Tokenization Configuration Options](docs/tests/secret-transform-tokenization.md)
-- [Transit Secret Configuration Options](docs/tests/secret-transit.md)
+- [AWS Secrets Engine Benchmark (`aws_secret`)](tests/secret-aws.md)
+- [Azure Secrets Engine Benchmark (`azure_secret`)](tests/secret-azure.md)
+- [Cassandra Secrets Engine Benchmark (`cassandra_secret`)](tests/secret-cassandra.md)
+- [Consul Secret Benchmark (`consul_secret`)](tests/secret-consul.md)
+- [Couchbase Secrets Engine Benchmark (`couchbase_secret`)](tests/secret-couchbase.md)
+- [Elasticsearch Secrets Engine Benchmark (`elasticsearch_secret`)](tests/secret-elasticsearch.md)
+- [GCP Secrets Engine Benchmark (`gcp_secret`)](tests/secret-gcp.md)
+- [GCP Secrets Engine Benchmark (`gcp_secret`)](tests/secret-impersonate-gcp.md)
+- [KVV1 and KVV2 Secret Benchmark](tests/secret-kv.md)
+- [LDAP Dynamic Secret Benchmark `ldap_dynamic_secret`](tests/secret-ldap-dynamic.md)
+- [LDAP Static Secret Benchmark `ldap_static_secret`](tests/secret-ldap-static.md)
+- [MongoDB Secrets Engine Benchmark](tests/secret-mongo.md)
+- [MongoDB Atlas Secrets Engine Benchmark](tests/secret-mongodb-atlas.md)
+- [MSSQL Secret Benchmark (`mssql_secret`)](tests/secret-mssql.md)
+- [MySQL Secret Benchmark `mysql_secret`](tests/secret-mysql.md)
+- [Nomad Secrets Engine Benchmark](tests/secret-nomad.md)
+- [PKI Secret Configuration Options](tests/secret-pki-issue.md)
+- [PKI Sign Secret Configuration Options](tests/secret-pki-sign.md)
+- [Postgresql Secrets Engine Benchmark `postgresql_secret`](tests/secret-postgresql.md)
+- [RabbitMQ Secret Configuration Options](tests/secret-rabbit.md)
+- [Redis Dynamic Credential Benchmark (`redis_dynamic_secret`)](tests/secret-redis-dynamic.md)
+- [Redis Static Credential Benchmark (`redis_static_secret`)](tests/secret-redis-static.md)
+- [Signed SSH Secret Issue Configuration Options](tests/secret-ssh-issue.md)
+- [SSH Key Signing Configuration Options](tests/secret-ssh-sign.md)
+- [Transform Tokenization Configuration Options](tests/secret-transform-tokenization.md)
+- [Transit Secret Configuration Options](tests/secret-transit.md)
 
 ### System Tests
 
-- [System Status Configuration Options](docs/tests/system-status.md)
+- [System Status Configuration Options](tests/system-status.md)
 
 ## Global Configuration Options
 


### PR DESCRIPTION
The generation script wasn't property generating the file links.  This fixes that and updates to the correct links