### PR TITLE
Added targets for secrets sync

### DIFF
--- a/benchmarktests/target_sync_aws.go
+++ b/benchmarktests/target_sync_aws.go
@@ -1,0 +1,289 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmarktests
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/vault/api"
+	"github.com/mitchellh/mapstructure"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+)
+
+const (
+	SyncEvents            = "events"
+	SyncAssociationsWrite = "associations_write"
+	SyncAssociationsRead  = "associations_read"
+
+	secretNameFormat     = "my-benchmark-secret-%d"
+	vaultTokenHeader     = "X-Vault-Token"
+	vaultNamespaceHeader = "X-Vault-Namespace"
+)
+
+func init() {
+	TestList[SyncEvents] = func() BenchmarkBuilder {
+		return &SyncAWSTest{
+			target: SyncEvents,
+		}
+	}
+	TestList[SyncAssociationsWrite] = func() BenchmarkBuilder {
+		return &SyncAWSTest{
+			target: SyncAssociationsWrite,
+		}
+	}
+	TestList[SyncAssociationsRead] = func() BenchmarkBuilder {
+		return &SyncAWSTest{
+			target: SyncAssociationsRead,
+		}
+	}
+}
+
+type SyncAWSTest struct {
+	target string
+	mount  string
+
+	config *SyncAWSTestConfig
+
+	logger hclog.Logger
+}
+
+type SyncAWSTestConfig struct {
+	NumAssociations   int               `hcl:"num_associations,optional"`
+	DestinationType   string            `hcl:"destination_type"`
+	DestinationName   string            `hcl:"destination_name"`
+	DestinationConfig map[string]string `hcl:"destination_config,optional"`
+}
+
+func (t *SyncAWSTest) ParseConfig(body hcl.Body) error {
+	cfg := &struct {
+		Config *SyncAWSTestConfig `hcl:"config,block"`
+	}{
+		// Defaults
+		Config: &SyncAWSTestConfig{
+			NumAssociations:   1,
+			DestinationConfig: map[string]string{},
+		},
+	}
+
+	diags := gohcl.DecodeBody(body, nil, cfg)
+	if diags.HasErrors() {
+		return fmt.Errorf("error decoding to struct: %v", diags)
+	}
+
+	t.config = cfg.Config
+
+	return nil
+}
+
+func (t *SyncAWSTest) Flags(_ *flag.FlagSet) {}
+
+func (t *SyncAWSTest) Setup(client *api.Client, mountName string, topLevelConfig *TopLevelTargetConfig) (BenchmarkBuilder, error) {
+	t.logger = targetLogger.Named(t.target)
+
+	// Create test mount
+	t.logger.Debug(mountLogMessage("secrets", "kvv2", mountName))
+
+	if topLevelConfig.RandomMounts {
+		mountName += "-" + uuid.New().String()
+	}
+	err := client.Sys().Mount(mountName, &api.MountInput{
+		Type: "kv",
+		Options: map[string]string{
+			"version": "2",
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error setupping KVv2 engine: %v", err)
+	}
+
+	// Create 1 secret to sync per association
+	for i := 0; i < t.config.NumAssociations; i++ {
+		secretName := fmt.Sprintf(secretNameFormat, i)
+		t.logger.Debug("creating secret on test mount", "mount", t.mount, "secret", secretName)
+
+		_, err := client.KVv2(mountName).Put(context.Background(), secretName, map[string]any{"key": uuid.New().String()})
+		if err != nil {
+			return nil, fmt.Errorf("error setupping secrets: %w", err)
+		}
+	}
+
+	// Create the test destination
+	t.logger.Debug("creating destination", "type", t.config.DestinationType, "name", t.config.DestinationName)
+
+	body := map[string]any{}
+	if err := mapstructure.Decode(t.config.DestinationConfig, &body); err != nil {
+		return nil, fmt.Errorf("error decoding destination config: %w", err)
+	}
+
+	_, err = client.Logical().Write(
+		fmt.Sprintf("/%s/destinations/%s/%s", t.GetTargetInfo().pathPrefix, t.config.DestinationType, t.config.DestinationName),
+		body,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error setupping destination: %w", err)
+	}
+
+	// If test is read or event based, pre-populate the associations
+	if t.target == SyncEvents || t.target == SyncAssociationsRead {
+		for i := 0; i < t.config.NumAssociations; i++ {
+			secretName := fmt.Sprintf(secretNameFormat, i)
+			t.logger.Debug("creating association", "mount", mountName, "secret", secretName)
+
+			_, err = client.Logical().Write(
+				fmt.Sprintf("/%s/destinations/%s/%s/associations/set", t.GetTargetInfo().pathPrefix, t.config.DestinationType, t.config.DestinationName),
+				map[string]any{"mount": mountName, "secret_name": secretName},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("error setupping associations: %w", err)
+			}
+		}
+	}
+
+	return &SyncAWSTest{
+		target: t.target,
+		config: t.config,
+		mount:  mountName,
+		logger: t.logger,
+	}, nil
+}
+
+func (t *SyncAWSTest) Cleanup(client *api.Client) error {
+	// Delete associations
+	for i := 0; i < t.config.NumAssociations; i++ {
+		secretName := fmt.Sprintf(secretNameFormat, i)
+		t.logger.Debug("deleting association for test secret", "mount", t.mount, "secret", secretName)
+
+		_, err := client.Logical().Write(
+			fmt.Sprintf("/%s/destinations/%s/%s/associations/remove", t.GetTargetInfo().pathPrefix, t.config.DestinationType, t.config.DestinationName),
+			map[string]any{"mount": t.mount, "secret_name": secretName},
+		)
+		if err != nil {
+			t.logger.Error("failed to clean association", "mount", t.mount, "secret", secretName, "error", err)
+		}
+	}
+
+	// Delete destination
+	t.logger.Debug("deleting destination", "type", t.config.DestinationType, "name", t.config.DestinationName)
+	_, err := client.Logical().Delete(
+		fmt.Sprintf("/%s/destinations/%s/%s", t.GetTargetInfo().pathPrefix, t.config.DestinationType, t.config.DestinationName),
+	)
+	if err != nil {
+		t.logger.Error("failed to clean destination", "type", t.config.DestinationType, "name", t.config.DestinationName, "error", err)
+	}
+
+	// Delete secrets
+	for i := 0; i < t.config.NumAssociations; i++ {
+		secretName := fmt.Sprintf(secretNameFormat, i)
+		t.logger.Debug("deleting test secret", "mount", t.mount, "secret", secretName)
+
+		err := client.KVv2(t.mount).Delete(context.Background(), fmt.Sprintf(secretNameFormat, i))
+		if err != nil {
+			t.logger.Error("failed to clean test secret", "mount", t.mount, "secret", secretName, "error", err)
+		}
+	}
+
+	// Unmount KVv2 engine
+	t.logger.Debug("deleting test engine", "mount", t.mount)
+	err = client.Sys().Unmount(t.mount)
+	if err != nil {
+		t.logger.Error("failed to unmount test engine", "mount", t.mount)
+	}
+
+	return nil
+}
+
+func (t *SyncAWSTest) GetTargetInfo() TargetInfo {
+	var method string
+	switch t.target {
+	case SyncAssociationsRead:
+		method = http.MethodGet
+	default:
+		method = http.MethodPost
+	}
+
+	return TargetInfo{
+		method:     method,
+		pathPrefix: "sys/sync",
+	}
+}
+
+func (t *SyncAWSTest) Target(client *api.Client) vegeta.Target {
+	switch t.target {
+	case SyncEvents:
+		return t.events(client)
+	case SyncAssociationsWrite:
+		return t.write(client)
+	default:
+		return t.read(client)
+	}
+}
+
+func (t *SyncAWSTest) events(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: t.GetTargetInfo().method,
+		URL: fmt.Sprintf("%s/v1/%s/data/%s",
+			client.Address(),
+			t.mount,
+			fmt.Sprintf(secretNameFormat,
+				int(rand.Int31n(int32(t.config.NumAssociations))),
+			),
+		),
+		Header: http.Header{
+			vaultTokenHeader:     []string{client.Token()},
+			vaultNamespaceHeader: []string{client.Namespace()}},
+		Body: []byte(
+			fmt.Sprintf(`{"data": {"foo": "%s"}}`,
+				uuid.New().String(),
+			),
+		),
+	}
+}
+
+func (t *SyncAWSTest) write(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: t.GetTargetInfo().method,
+		URL: fmt.Sprintf("%s/v1/%s/destinations/%s/%s/associations/set",
+			client.Address(),
+			t.GetTargetInfo().pathPrefix,
+			t.config.DestinationType,
+			t.config.DestinationName,
+		),
+		Header: http.Header{
+			vaultTokenHeader:     []string{client.Token()},
+			vaultNamespaceHeader: []string{client.Namespace()}},
+		Body: []byte(
+			fmt.Sprintf(`{"mount": "%s", "secret_name": "%s"}`,
+				t.mount,
+				fmt.Sprintf(secretNameFormat,
+					int(rand.Int31n(int32(t.config.NumAssociations))),
+				),
+			),
+		),
+	}
+}
+
+func (t *SyncAWSTest) read(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: t.GetTargetInfo().method,
+		URL: fmt.Sprintf("%s/v1/%s/associations/destinations?mount=%s&secret_name=%s",
+			client.Address(),
+			t.GetTargetInfo().pathPrefix,
+			t.mount,
+			fmt.Sprintf(secretNameFormat,
+				int(rand.Int31n(int32(t.config.NumAssociations))),
+			),
+		),
+		Header: http.Header{
+			vaultTokenHeader:     []string{client.Token()},
+			vaultNamespaceHeader: []string{client.Namespace()}},
+	}
+}

--- a/docs/tests/secret-sync.md
+++ b/docs/tests/secret-sync.md
@@ -1,0 +1,88 @@
+# Secrets Sync Benchmark
+
+This benchmark tests the performance of the secrets sync feature. 
+
+## Test Parameters
+
+### Configuration `config`
+
+- `num_associations` `(int: 3)` - the number of associations to create. An association is the link that syncs one Vault 
+secret as an external secret with one destination. For read and event-based test targets, the associations are created
+during the setup phase. For write-based targets, the associations are created and updated as part of the load test.
+- `destination_type` `(string: <required>)`:  The type of destination to sync the test secrets with, e.g. aw-sm. Refer to
+the [Vault documentation](https://developer.hashicorp.com/vault/docs/sync) for the complete set of supported types.
+- `destination_name` `(string: "benchmark-test-<UUID>")`:  The name of destination used to benchmark the sync operations.
+- `destination_config` `(map<string|string>: <optional>)`:  The config to pass when creating the benchmark destination.
+Refer to the [Vault documentation](https://developer.hashicorp.com/vault/docs/sync) or the examples below for the list 
+of supported fields for each destination type.
+
+## Example Configuration
+
+```hcl
+test "associations_write" "test_aws" {
+  weight = 20
+  config {
+    num_associations = 50
+    destination_type = "aws-sm"
+    destination_name = "my-dest-1"
+    destination_config = {
+      access_key_id = "AKI..."
+      secret_access_key = "j2m..."
+      region = "us-east-2"
+    }
+  }
+}
+
+test "associations_write" "test_azure" {
+  weight = 20
+  config {
+    num_associations = 50
+    destination_type = "azure-kv"
+    destination_name = "my-dest-2"
+    destination_config = {
+      key_vault_uri: "https://keyvault-1234.vault.azure.net",
+      tenant_id: "<UUID>",
+      client_id: "<UUID>",
+      client_secret: "9Oy8..."
+    }
+  }
+}
+
+test "events" "test_gcp" {
+  weight = 20
+  config {
+    num_associations = 50
+    destination_type = "gcp-sm"
+    destination_name = "my-dest-3"
+    destination_config = {
+        credentials = '@path/to/credentials.json'
+    }
+  }
+}
+
+test "associations_read" "test_github" {
+  weight = 20
+  config {
+    num_associations = 1
+    destination_type = "gh"
+    destination_config = {
+        access_token = "github_pat_1234"
+        repository_owner = "hashicorp"
+        repository_name = "vault-benchmark"
+    }
+  }
+}
+
+test "associations_read" "test_vercel" {
+  weight = 20
+  config {
+    num_associations = 5
+    destination_type = "vercel-project"
+    destination_config = {
+      access_token": "ujhM7...",
+      project_id": "prj_1234",
+      deployment_environments": ["development", "preview", "production"]
+    }
+  }
+}
+```


### PR DESCRIPTION
Added 3 targets to load test the secrets sync feature.

Example of a run using all 3:

https://github.com/hashicorp/vault-benchmark/assets/109547106/a79975de-c3d4-4cc9-ac80-1a4c4ce41b91

Config example:
```
# Vault settings
vault_addr = "http://127.0.0.1:8200"
vault_token = "root"
vault_namespace = "root"
# Load settings
workers = 10
duration = "30s"
# Test settings
random_mounts = true
cleanup = true
audits_path = "/home/max/projects-playground/vault-benchmark/audits.txt"
log_level = "TRACE"
report_mode = "verbose"

# Tests
test "associations_write" "test_mount" {
  weight = 33
  config {
    num_associations = 50
    destination_type = "aws-sm"
    destination_name = "my-dest-1"
    destination_config = {
        #access_key_id = "AKI..."
        #secret_access_key = "j2m..."
        region = "us-east-2"
    }
  }
}
test "associations_read" "test_mount" {
  weight = 33
  config {
    num_associations = 5
    destination_type = "aws-sm"
    destination_name = "my-dest-2"
    destination_config = {
        #access_key_id = "AKI..."
        #secret_access_key = "j2m..."
        region = "us-east-2"
    }
  }
}
test "events" "test_mount" {
  weight = 34
  config {
    num_associations = 1
    destination_type = "aws-sm"
    destination_name = "my-dest-3"
    destination_config = {
        #access_key_id = "AKI..."
        #secret_access_key = "j2m..."
        region = "us-east-2"
    }
  }
}
```