### PR TITLE
Remove release-engineering as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,3 @@
 * @hashicorp/vault-customer-engineering
 
 # release configuration
-/.release/                              @hashicorp/release-engineering
-/.github/workflows/build.yml            @hashicorp/release-engineering


### PR DESCRIPTION
Removing @hashicorp/release-engineering from the CODEOWNERS file in this repo (on main).
Feel free to backport this change to other active branches.
The intention is to free teams up to merge changes without our team being a blocker.
As always, please ping us in #team-rel-eng if you have any questions on build/release config
changes and/or want a second pair of eyes on anything!
Thanks,
team-rel-eng

[_Created by Sourcegraph batch change `rel-eng/update-releng-codeowners`._](https://hashicorp.sourcegraph.com/organizations/rel-eng/batch-changes/update-releng-codeowners)