### PR TITLE
Fix postgres nil logger panic

### DIFF
--- a/benchmarktests/target_secret_postgres.go
+++ b/benchmarktests/target_secret_postgres.go
@@ -201,6 +201,7 @@ func (s *PostgreSQLSecret) Setup(client *api.Client, mountName string, topLevelC
 		pathPrefix: "/v1/" + secretPath,
 		header:     generateHeader(client),
 		roleName:   s.config.PostgreSQLRoleConfig.Name,
+		logger:     s.logger,
 	}, nil
 
 }

--- a/helper/dockertest/dockerjobs/benchmark_run.go
+++ b/helper/dockertest/dockerjobs/benchmark_run.go
@@ -49,7 +49,7 @@ func CreateVaultBenchmarkContainer(t *testing.T, vaultAddr string, vaultToken st
 		DoNotAutoRemove: true,
 		Env:             []string{fmt.Sprintf("VAULT_ADDR=%s", vaultAddr), fmt.Sprintf("VAULT_TOKEN=%s", vaultToken)},
 		CopyFromTo:      volume,
-		Cmd:             []string{"/bin/vault-benchmark", "run", fmt.Sprintf("-config=/etc/%s", configFile)},
+		Cmd:             []string{"/bin/vault-benchmark", "run", fmt.Sprintf("-config=/etc/%s", configFile), "-cleanup=true"},
 	}
 
 	runner, err := dockhelper.NewServiceRunner(runOpts)

--- a/test-fixtures/target_secret_postgres_test.go
+++ b/test-fixtures/target_secret_postgres_test.go
@@ -36,7 +36,7 @@ func TestPostgres_Secret_Docker(t *testing.T) {
 
 	var expectedCode int64 = 0
 	if exitCode != expectedCode {
-		t.Logf("Expected return code: %d. Actual return code: %d", expectedCode, exitCode)
+		t.Fatalf("Expected return code: %d. Actual return code: %d", expectedCode, exitCode)
 	}
 }
 


### PR DESCRIPTION
Logger isn't returned during setup so a panic occurs during the clean up stage:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0xd2a916]

goroutine 45 [running]:
github.com/hashicorp/vault-benchmark/benchmarktests.(*PostgreSQLSecret).Cleanup(0xc00059c300, 0xc000237b80)
	github.com/hashicorp/vault-benchmark/benchmarktests/target_secret_postgres.go:132 +0x76
github.com/hashicorp/vault-benchmark/benchmarktests.TargetMulti.Cleanup.func1()
	github.com/hashicorp/vault-benchmark/benchmarktests/benchmark_targets.go:124 +0x76
created by github.com/hashicorp/vault-benchmark/benchmarktests.TargetMulti.Cleanup
	github.com/hashicorp/vault-benchmark/benchmarktests/benchmark_targets.go:121 +0x4ae
```