### PR TITLE
Fix cassandra nil logger panic

### DIFF
--- a/benchmarktests/target_secret_cassandra.go
+++ b/benchmarktests/target_secret_cassandra.go
@@ -210,6 +210,7 @@ func (c *CassandraSecret) Setup(client *api.Client, mountName string, topLevelCo
 		pathPrefix: "/v1/" + secretPath,
 		header:     generateHeader(client),
 		roleName:   c.config.CassandraRoleConfig.Name,
+		logger:     c.logger,
 	}, nil
 
 }


### PR DESCRIPTION
It seems like this only happens when cleanup flag is included. 