### PR TITLE
Fix nil logger panic in couchbase

### DIFF
--- a/benchmarktests/target_secret_couchbase.go
+++ b/benchmarktests/target_secret_couchbase.go
@@ -193,6 +193,7 @@ func (c *CouchbaseSecretTest) Setup(client *api.Client, mountName string, topLev
 		pathPrefix: "/v1/" + secretPath,
 		header:     generateHeader(client),
 		roleName:   c.config.RoleConfig.Name,
+		logger:     c.logger,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes a panic similar to #186 and #187 