### PR TITLE
fix CVEs for Alpine Linux's Security container

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,6 +5,14 @@ container {
   dependencies = true
   alpine_secdb = true
   secrets      = true
+  triage {
+    suppress {
+      vulnerabilities = [
+        "CVE-2025-46394", // busybox@1.37.0-r18
+        "CVE-2024-58251", // busybox@1.37.0-r18
+      ]
+    }
+  }
 }
 
 binary {


### PR DESCRIPTION
Suppressing CVEs flagged in Alpine’s busybox. These vulnerabilities are not yet patched upstream and will auto-resolve once Alpine releases the fixed packages.