### PR TITLE
feat: add transform_fpe benchmark test type for Format Preserving Encryption (FPE) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ dist/
 # IDE specific stuff
 .idea/
 .vscode/
+
+# Vault benchmark test configs (contain sensitive tokens/addresses)
+fpe-test*.hcl
+
+# Test results and logs (may contain sensitive cluster information)
+results/
+*.log

--- a/benchmarktests/target_secret_transform_fpe.go
+++ b/benchmarktests/target_secret_transform_fpe.go
@@ -1,0 +1,183 @@
+// Copyright IBM Corp. 2022, 2025
+// SPDX-License-Identifier: MPL-2.0
+package benchmarktests
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/vault/api"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+)
+
+const (
+	TransformFPETestType   = "transform_fpe"
+	TransformFPETestMethod = "POST"
+)
+
+func init() {
+	TestList[TransformFPETestType] = func() BenchmarkBuilder {
+		return &TransformFPETest{}
+	}
+}
+
+type TransformFPETest struct {
+	pathPrefix string
+	header     http.Header
+	body       []byte
+	roleName   string
+	config     *TransformFPETestConfig
+	logger     hclog.Logger
+}
+type TransformFPETestConfig struct {
+	RoleConfig  *TransformRoleConfig  `hcl:"role,block"`
+	FPEConfig   *TransformFPEConfig   `hcl:"fpe,block"`
+	InputConfig *TransformInputConfig `hcl:"input,block"`
+}
+type TransformFPEConfig struct {
+	Name         string   `hcl:"name,optional"`
+	Template     string   `hcl:"template,optional"`
+	TweakSource  string   `hcl:"tweak_source,optional"`
+	AllowedRoles []string `hcl:"allowed_roles,optional"`
+}
+type TransformFPETemplateConfig struct {
+	Name     string `hcl:"name,optional"`
+	Type     string `hcl:"type,optional"`
+	Pattern  string `hcl:"pattern,optional"`
+	Alphabet string `hcl:"alphabet,optional"`
+}
+
+func (t *TransformFPETest) ParseConfig(body hcl.Body) error {
+	testConfig := &struct {
+		Config *TransformFPETestConfig `hcl:"config,block"`
+	}{
+		Config: &TransformFPETestConfig{
+			RoleConfig: &TransformRoleConfig{
+				Name:            "benchmark-role",
+				Transformations: []string{"benchmarkfpetransformation"},
+			},
+			FPEConfig: &TransformFPEConfig{
+				Name:         "benchmarkfpetransformation",
+				Template:     "benchmarkfpetemplate",
+				TweakSource:  "internal",
+				AllowedRoles: []string{"benchmark-role"},
+			},
+			InputConfig: &TransformInputConfig{
+				Transformation: "benchmarkfpetransformation",
+				Value:          "1111-2222-3333-4444",
+			},
+		},
+	}
+	diags := gohcl.DecodeBody(body, nil, testConfig)
+	if diags.HasErrors() {
+		return fmt.Errorf("error decoding to struct: %v", diags)
+	}
+	t.config = testConfig.Config
+	return nil
+}
+func (t *TransformFPETest) Target(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: TransformFPETestMethod,
+		URL:    client.Address() + t.pathPrefix + "/encode/" + t.roleName,
+		Body:   t.body,
+		Header: t.header,
+	}
+}
+func (t *TransformFPETest) GetTargetInfo() TargetInfo {
+	return TargetInfo{
+		method:     TransformFPETestMethod,
+		pathPrefix: t.pathPrefix,
+	}
+}
+func (t *TransformFPETest) Cleanup(client *api.Client) error {
+	t.logger.Trace(cleanupLogMessage(t.pathPrefix))
+	_, err := client.Logical().Delete(strings.Replace(t.pathPrefix, "/v1/", "/sys/mounts/", 1))
+	if err != nil {
+		return fmt.Errorf("error cleaning up mount: %v", err)
+	}
+	return nil
+}
+func (t *TransformFPETest) Setup(client *api.Client, mountName string, topLevelConfig *TopLevelTargetConfig) (BenchmarkBuilder, error) {
+	var err error
+	secretPath := mountName
+	t.logger = targetLogger.Named(TransformFPETestType)
+	if topLevelConfig.RandomMounts {
+		secretPath, err = uuid.GenerateUUID()
+		if err != nil {
+			log.Fatalf("can't create UUID")
+		}
+	}
+	// Create Transform mount
+	t.logger.Trace(mountLogMessage("secrets", "transform", secretPath))
+	err = client.Sys().Mount(secretPath, &api.MountInput{
+		Type: "transform",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error mounting transform secrets engine: %v", err)
+	}
+	setupLogger := t.logger.Named(secretPath)
+	// Create FPE Template
+	setupLogger.Trace(writingLogMessage("fpe template"), "name", t.config.FPEConfig.Template)
+	templatePath := filepath.Join(secretPath, "template", t.config.FPEConfig.Template)
+	_, err = client.Logical().Write(templatePath, map[string]interface{}{
+		"type":     "regex",
+		"pattern":  `(\d{4})-(\d{4})-(\d{4})-(\d{4})`,
+		"alphabet": "builtin/numeric",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error writing FPE template %q: %v", t.config.FPEConfig.Template, err)
+	}
+	// Decode FPE Transformation config
+	setupLogger.Trace(parsingConfigLogMessage("fpe"))
+	fpeConfigData, err := structToMap(t.config.FPEConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing FPE config from struct: %v", err)
+	}
+	// Create FPE Transformation
+	setupLogger.Trace(writingLogMessage("fpe transformation"), "name", t.config.FPEConfig.Name)
+	transformationPath := filepath.Join(secretPath, "transformations", "fpe", t.config.FPEConfig.Name)
+	_, err = client.Logical().Write(transformationPath, fpeConfigData)
+	if err != nil {
+		return nil, fmt.Errorf("error writing FPE transformation %q: %v", t.config.FPEConfig.Name, err)
+	}
+	// Decode Role config
+	setupLogger.Trace(parsingConfigLogMessage("role"))
+	roleConfigData, err := structToMap(t.config.RoleConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing role config from struct: %v", err)
+	}
+	// Create Role
+	setupLogger.Trace(writingLogMessage("role"), "name", t.config.RoleConfig.Name)
+	rolePath := filepath.Join(secretPath, "role", t.config.RoleConfig.Name)
+	_, err = client.Logical().Write(rolePath, roleConfigData)
+	if err != nil {
+		return nil, fmt.Errorf("error writing role %q: %v", t.config.RoleConfig.Name, err)
+	}
+	// Decode test input data
+	setupLogger.Trace("parsing test transformation input data")
+	testData, err := structToMap(t.config.InputConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing test transformation input data from struct: %v", err)
+	}
+	testDataString, err := json.Marshal(testData)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling test encode data: %v", err)
+	}
+	return &TransformFPETest{
+		pathPrefix: "/v1/" + secretPath,
+		header:     generateHeader(client),
+		body:       []byte(testDataString),
+		roleName:   t.config.RoleConfig.Name,
+		logger:     t.logger,
+	}, nil
+}
+func (t *TransformFPETest) Flags(fs *flag.FlagSet) {}

--- a/benchmarktests/target_secret_transform_fpe_test.go
+++ b/benchmarktests/target_secret_transform_fpe_test.go
@@ -1,0 +1,244 @@
+// Copyright IBM Corp. 2022, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmarktests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestTransformFPETest_Registered(t *testing.T) {
+	builder, ok := TestList[TransformFPETestType]
+	if !ok {
+		t.Fatalf("expected %q to be registered", TransformFPETestType)
+	}
+
+	if _, ok := builder().(*TransformFPETest); !ok {
+		t.Fatalf("expected registered builder to return *TransformFPETest")
+	}
+}
+
+func TestTransformFPETest_ParseConfig(t *testing.T) {
+	tAuth := TransformFPETest{}
+
+	hclFile, diags := hclparse.NewParser().ParseHCLFile(filepath.Join(FixturePath, "secret_transform_fpe.hcl"))
+	if diags != nil {
+		t.Fatalf("err: %v", diags)
+	}
+
+	err := tAuth.ParseConfig(hclFile.Body)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if tAuth.config == nil {
+		t.Fatal("expected config to be populated")
+	}
+
+	if tAuth.config.RoleConfig.Name != "custom-role" {
+		t.Fatalf("expected role name custom-role, got %q", tAuth.config.RoleConfig.Name)
+	}
+
+	if !reflect.DeepEqual(tAuth.config.RoleConfig.Transformations, []string{"custom-fpe"}) {
+		t.Fatalf("unexpected role transformations: %#v", tAuth.config.RoleConfig.Transformations)
+	}
+
+	if tAuth.config.FPEConfig.Name != "custom-fpe" {
+		t.Fatalf("expected FPE name custom-fpe, got %q", tAuth.config.FPEConfig.Name)
+	}
+
+	if tAuth.config.FPEConfig.Template != "custom-template" {
+		t.Fatalf("expected template custom-template, got %q", tAuth.config.FPEConfig.Template)
+	}
+
+	if tAuth.config.FPEConfig.TweakSource != "supplied" {
+		t.Fatalf("expected tweak source supplied, got %q", tAuth.config.FPEConfig.TweakSource)
+	}
+
+	if !reflect.DeepEqual(tAuth.config.FPEConfig.AllowedRoles, []string{"custom-role"}) {
+		t.Fatalf("unexpected allowed roles: %#v", tAuth.config.FPEConfig.AllowedRoles)
+	}
+
+	if tAuth.config.InputConfig.Value != "1234-5678-9012-3456" {
+		t.Fatalf("expected custom input value, got %q", tAuth.config.InputConfig.Value)
+	}
+
+	if tAuth.config.InputConfig.Transformation != "custom-fpe" {
+		t.Fatalf("expected custom input transformation, got %q", tAuth.config.InputConfig.Transformation)
+	}
+
+	if tAuth.config.InputConfig.Tweak != "H0mSPAfSJg==" {
+		t.Fatalf("expected custom tweak, got %q", tAuth.config.InputConfig.Tweak)
+	}
+}
+
+func TestTransformFPETest_SetupTargetAndCleanup(t *testing.T) {
+	targetLogger = hclog.NewNullLogger()
+
+	type requestRecord struct {
+		method string
+		path   string
+		body   map[string]interface{}
+	}
+
+	var mu sync.Mutex
+	var handlerErr error
+	var requests []requestRecord
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		record := requestRecord{method: r.Method, path: r.URL.Path}
+		payload, err := io.ReadAll(r.Body)
+		if err != nil {
+			handlerErr = fmt.Errorf("failed reading request body: %w", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if len(payload) > 0 {
+			if err := json.Unmarshal(payload, &record.body); err != nil {
+				handlerErr = fmt.Errorf("failed decoding request body: %w", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+		mu.Lock()
+		requests = append(requests, record)
+		mu.Unlock()
+
+		if r.URL.Path == "/v1/sys/mounts/fpe-test" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer server.Close()
+
+	client, err := api.NewClient(&api.Config{Address: server.URL, HttpClient: server.Client()})
+	if err != nil {
+		t.Fatalf("failed creating client: %v", err)
+	}
+	client.SetToken("root-token")
+	client.SetNamespace("admin")
+
+	tAuth := &TransformFPETest{}
+	hclFile, diags := hclparse.NewParser().ParseHCLFile(filepath.Join(FixturePath, "secret_transform_fpe.hcl"))
+	if diags != nil {
+		t.Fatalf("err: %v", diags)
+	}
+
+	err = tAuth.ParseConfig(hclFile.Body)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	builder, err := tAuth.Setup(client, "fpe-test", &TopLevelTargetConfig{RandomMounts: false})
+	if err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	fpeTest, ok := builder.(*TransformFPETest)
+	if !ok {
+		t.Fatalf("expected builder type *TransformFPETest, got %T", builder)
+	}
+
+	if fpeTest.pathPrefix != "/v1/fpe-test" {
+		t.Fatalf("expected path prefix /v1/fpe-test, got %q", fpeTest.pathPrefix)
+	}
+
+	if fpeTest.roleName != "custom-role" {
+		t.Fatalf("expected role name custom-role, got %q", fpeTest.roleName)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(fpeTest.body, &body); err != nil {
+		t.Fatalf("failed to unmarshal target body: %v", err)
+	}
+
+	if body["value"] != "1234-5678-9012-3456" {
+		t.Fatalf("expected request value to match config, got %#v", body["value"])
+	}
+
+	if body["transformation"] != "custom-fpe" {
+		t.Fatalf("expected transformation to match config, got %#v", body["transformation"])
+	}
+
+	if body["tweak"] != "H0mSPAfSJg==" {
+		t.Fatalf("expected tweak to match config, got %#v", body["tweak"])
+	}
+
+	target := fpeTest.Target(client)
+	if target.Method != TransformFPETestMethod {
+		t.Fatalf("expected target method %q, got %q", TransformFPETestMethod, target.Method)
+	}
+
+	if target.URL != server.URL+"/v1/fpe-test/encode/custom-role" {
+		t.Fatalf("unexpected target URL: %q", target.URL)
+	}
+
+	if got := target.Header.Get("X-Vault-Token"); got != "root-token" {
+		t.Fatalf("expected X-Vault-Token header to be set, got %q", got)
+	}
+
+	if got := target.Header.Get("X-Vault-Namespace"); got != "admin" {
+		t.Fatalf("expected X-Vault-Namespace header to be set, got %q", got)
+	}
+
+	err = fpeTest.Cleanup(client)
+	if err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+
+	if handlerErr != nil {
+		t.Fatalf("handler error: %v", handlerErr)
+	}
+
+	if len(requests) != 5 {
+		t.Fatalf("expected 5 requests during setup and cleanup, got %d", len(requests))
+	}
+
+	assertRequestPath(t, requests[0], http.MethodPost, "/v1/sys/mounts/fpe-test")
+	assertRequestPath(t, requests[1], http.MethodPut, "/v1/fpe-test/template/custom-template")
+	assertRequestPath(t, requests[2], http.MethodPut, "/v1/fpe-test/transformations/fpe/custom-fpe")
+	assertRequestPath(t, requests[3], http.MethodPut, "/v1/fpe-test/role/custom-role")
+	assertRequestPath(t, requests[4], http.MethodDelete, "/v1/sys/mounts/fpe-test")
+
+	if requests[1].body["type"] != "regex" {
+		t.Fatalf("expected template type regex, got %#v", requests[1].body["type"])
+	}
+
+	if requests[2].body["template"] != "custom-template" {
+		t.Fatalf("expected transformation template custom-template, got %#v", requests[2].body["template"])
+	}
+
+	if requests[3].body["name"] != "custom-role" {
+		t.Fatalf("expected role payload to include name custom-role, got %#v", requests[3].body["name"])
+	}
+}
+
+func assertRequestPath(t *testing.T, request struct {
+	method string
+	path   string
+	body   map[string]interface{}
+}, method string, path string) {
+	t.Helper()
+	if request.method != method {
+		t.Fatalf("expected method %q, got %q", method, request.method)
+	}
+	if request.path != path {
+		t.Fatalf("expected path %q, got %q", path, request.path)
+	}
+}

--- a/docs/tests/secret-transform-fpe.md
+++ b/docs/tests/secret-transform-fpe.md
@@ -1,0 +1,104 @@
+# Transform FPE (Format Preserving Encryption) Configuration Options
+
+This benchmark will test Vault's Transform secrets engine by performing Format Preserving Encryption (FPE) encoding on provided input using the FF3-1 algorithm.
+
+## Test Parameters
+
+### Role Config `role`
+
+- `name` `(string: "benchmark-role")` –
+  Specifies the name of the role to create. This is part of the request URL.
+
+- `transformations` (`list: ["benchmarkfpetransformation"]`) -
+  Specifies the transformations that can be used with this role.
+
+### FPE Config `fpe`
+
+- `name` `(string: "benchmarkfpetransformation")` –
+  Specifies the name of the FPE transformation to create or update. This is part
+  of the request URL.
+
+- `template` `(string: "benchmarkfpetemplate")` –
+  Specifies the template to use for FPE encoding. The template defines the
+  format and alphabet of the data to be encrypted.
+
+- `tweak_source` `(string: "internal")` –
+  Specifies the source of the tweak value. Options are `internal`, `generated`,
+  and `supplied`. When set to `internal`, Vault generates and stores the tweak
+  internally. When set to `generated`, Vault generates a tweak and returns it
+  with the response. When set to `supplied`, the caller must provide a tweak
+  value with every encode request.
+
+- `allowed_roles` `(list: ["benchmark-role"])` –
+  Specifies a list of allowed roles that this transformation can be assigned to.
+  A role using this transformation must exist in this list in order for
+  encode and decode operations to properly function.
+
+### Encode Input `input`
+
+- `role_name` `(string: "benchmark-role")` –
+  Specifies the role name to use for this operation. This is specified as part
+  of the URL.
+
+- `value` `(string: "1111-2222-3333-4444")` –
+  Specifies the value to be encoded. Must match the format defined in the
+  transformation template.
+
+- `transformation` `(string: "benchmarkfpetransformation")` –
+  Specifies the transformation within the role that should be used for this
+  encode operation. If a single transformation exists for role, this parameter
+  may be skipped and will be inferred. If multiple transformations exist, one
+  must be specified.
+
+- `tweak` `(string)` –
+  Specifies the **base64 encoded** tweak to use. Only applicable for FPE
+  transformations with `supplied` as the tweak source. The tweak must be a
+  7-byte value that is then base64 encoded.
+
+- `reference` `(string: "")` -
+  A user-supplied string that will be present in the `reference` field on the
+  corresponding `batch_results` item in the response, to assist in understanding
+  which result corresponds to a particular input. Only valid on batch requests
+  when using 'batch_input' below.
+
+- `batch_input` `(array<object>: nil)` -
+  Specifies a list of items to be encoded in a single batch. When this
+  parameter is set, the 'value', 'transformation', 'tweak' and
+  'reference' parameters are ignored. Instead, the aforementioned parameters
+  should be provided within each object in the list.
+```json
+  [
+    {
+      "value": "1111-2222-3333-4444",
+      "transformation": "benchmarkfpetransformation"
+    },
+    {
+      "value": "5555-6666-7777-8888",
+      "transformation": "benchmarkfpetransformation",
+      "tweak": "H0mSPAfSJg=="
+    }
+  ]
+```
+
+### Example Configuration
+```hcl
+test "transform_fpe" "fpe_test" {
+  weight = 100
+  config {
+    role {
+      name            = "benchmark-role"
+      transformations = ["benchmarkfpetransformation"]
+    }
+    fpe {
+      name          = "benchmarkfpetransformation"
+      template      = "benchmarkfpetemplate"
+      tweak_source  = "internal"
+      allowed_roles = ["benchmark-role"]
+    }
+    input {
+      value          = "1111-2222-3333-4444"
+      transformation = "benchmarkfpetransformation"
+    }
+  }
+}
+```

--- a/test-fixtures/configs/secret_transform_fpe.hcl
+++ b/test-fixtures/configs/secret_transform_fpe.hcl
@@ -1,0 +1,19 @@
+config {
+  role {
+    name            = "custom-role"
+    transformations = ["custom-fpe"]
+  }
+
+  fpe {
+    name          = "custom-fpe"
+    template      = "custom-template"
+    tweak_source  = "supplied"
+    allowed_roles = ["custom-role"]
+  }
+
+  input {
+    value          = "1234-5678-9012-3456"
+    transformation = "custom-fpe"
+    tweak          = "H0mSPAfSJg=="
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a new `transform_fpe` benchmark test type to support Format Preserving Encryption (FPE) benchmarking using Vault's Transform Secrets Engine.

## Changes
- Add `benchmarktests/target_secret_transform_fpe.go` implementing the `transform_fpe` test type
- Add `docs/tests/secret-transform-fpe.md` with configuration and usage documentation
- Add unit tests for `transform_fpe`
- Add an HCL fixture for config parsing coverage

## Features
- Supports all three tweak sources: `internal`, `generated`, and `supplied`
- Automatically creates the FPE template, transformation, and role during setup
- Cleans up created resources when `cleanup = true`

## Testing
Added unit coverage for:
- registration of `transform_fpe`
- HCL config parsing
- setup / target / cleanup flow against a mocked Vault API

Targeted test status:
- `go test ./benchmarktests -run TransformFPETest -v` passes

Repo-wide test status:
- `go test ./...` still only fails in the repo's existing Docker-backed tests under `test-fixtures` when Docker is unavailable (`Cannot connect to the Docker daemon at unix:///var/run/docker.sock`)

HCP validation output:
- supplied tweak: count 2240, throughput 37.154109 req/s, mean 268.279325ms, p95 288.924115ms, p99 341.030866ms, success 100%
- internal tweak: count 2229, throughput 36.985815 req/s, mean 269.681022ms, p95 279.109931ms, p99 363.232827ms, success 100%
- generated tweak: count 2289, throughput 37.958554 req/s, mean 262.850362ms, p95 272.670632ms, p99 309.930134ms, success 100%