### PR TITLE
Add no_store_metadata support for KVV2 and PKI benchmark tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Features
 
 - Add `no_store_metadata` support for KVV2 benchmark tests
+- Add `no_store_metadata` support for PKI issue role config
 
 ## [v0.4.1](https://github.com/hashicorp/vault-benchmark/tree/v0.4.1) (Dec 29, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased](https://github.com/hashicorp/vault-benchmark/tree/HEAD)
 
+### Features
+
+- Add `no_store_metadata` support for KVV2 benchmark tests
+
 ## [v0.4.1](https://github.com/hashicorp/vault-benchmark/tree/v0.4.1) (Dec 29, 2025)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Features
 
 - Add `no_store_metadata` support for KVV2 benchmark tests
-- Add `no_store_metadata` support for PKI issue role config
+- Add `no_store_metadata` support for PKI issue and sign role configs
 
 ## [v0.4.1](https://github.com/hashicorp/vault-benchmark/tree/v0.4.1) (Dec 29, 2025)
 

--- a/benchmarktests/target_secret_kvv2.go
+++ b/benchmarktests/target_secret_kvv2.go
@@ -48,8 +48,9 @@ type KVV2Test struct {
 }
 
 type KVV2SecretTestConfig struct {
-	KVSize int `hcl:"kvsize,optional"`
-	NumKVs int `hcl:"numkvs,optional"`
+	KVSize          int  `hcl:"kvsize,optional"`
+	NumKVs          int  `hcl:"numkvs,optional"`
+	NoStoreMetadata bool `hcl:"no_store_metadata,optional"`
 }
 
 func (k *KVV2Test) ParseConfig(body hcl.Body) error {
@@ -151,6 +152,16 @@ func (k *KVV2Test) Setup(client *api.Client, mountName string, topLevelConfig *T
 	}
 
 	setupLogger := k.logger.Named(mountPath)
+
+	if k.config.NoStoreMetadata {
+		setupLogger.Trace("configuring no_store_metadata")
+		_, err = client.Logical().Write(mountPath+"/config", map[string]interface{}{
+			"no_store_metadata": true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error configuring kv secrets engine: %v", err)
+		}
+	}
 
 	secval := map[string]interface{}{
 		"data": map[string]interface{}{

--- a/benchmarktests/target_secret_kvv2_test.go
+++ b/benchmarktests/target_secret_kvv2_test.go
@@ -1,0 +1,29 @@
+// Copyright IBM Corp. 2022, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmarktests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclparse"
+)
+
+func TestKVV2Test_ParseConfig(t *testing.T) {
+	k := KVV2Test{}
+
+	hclFile, diags := hclparse.NewParser().ParseHCLFile(filepath.Join(FixturePath, "kvv2.hcl"))
+	if diags != nil {
+		t.Fatalf("err: %v", diags)
+	}
+
+	err := k.ParseConfig(hclFile.Body)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if !k.config.NoStoreMetadata {
+		t.Fatal("expected no_store_metadata to be true")
+	}
+}

--- a/benchmarktests/target_secret_pki_issue.go
+++ b/benchmarktests/target_secret_pki_issue.go
@@ -215,6 +215,7 @@ type PKIIssueRoleConfig struct {
 	PostalCode                   string   `hcl:"postal_code,optional"`
 	GenerateLease                bool     `hcl:"generate_lease,optional"`
 	NoStore                      bool     `hcl:"no_store,optional"`
+	NoStoreMetadata              bool     `hcl:"no_store_metadata,optional"`
 	RequireCN                    *bool    `hcl:"require_cn,optional"`
 	PolicyIdentifiers            []string `hcl:"policy_identifiers,optional"`
 	BasicConstrainsValidForNonCA bool     `hcl:"basic_constraints_valid_for_non_ca,optional"`

--- a/benchmarktests/target_secret_pki_sign.go
+++ b/benchmarktests/target_secret_pki_sign.go
@@ -221,6 +221,7 @@ type pkiSignRoleConfig struct {
 	PostalCode                   string   `hcl:"postal_code,optional"`
 	GenerateLease                bool     `hcl:"generate_lease,optional"`
 	NoStore                      bool     `hcl:"no_store,optional"`
+	NoStoreMetadata              bool     `hcl:"no_store_metadata,optional"`
 	RequireCN                    *bool    `hcl:"require_cn,optional"`
 	PolicyIdentifiers            []string `hcl:"policy_identifiers,optional"`
 	BasicConstrainsValidForNonCA bool     `hcl:"basic_constraints_valid_for_non_ca,optional"`

--- a/docs/tests/secret-kv.md
+++ b/docs/tests/secret-kv.md
@@ -10,6 +10,7 @@ This benchmark tests the performance of KVV1 and/or KVV2.  It writes a set numbe
 then this many keys will be written during the setup phase.  The read operations
 will read from these keys, and the write operations overwrite them.
 - `kvsize` `(int: 1)`:  the size of the key and value to write.
+- `no_store_metadata` `(bool: false)` **(KVV2 only)**: if `true`, configures the KV v2 secrets engine with `no_store_metadata`, which disables storing metadata separately and can improve write performance.
 
 ## Example Configuration
 

--- a/docs/tests/secret-kv.md
+++ b/docs/tests/secret-kv.md
@@ -30,3 +30,24 @@ test "kvv2_write" "kvv2_write_test" {
     }
 }
 ```
+
+### Example with `no_store_metadata`
+
+```hcl
+test "kvv2_read" "kvv2_read_test" {
+    weight = 50
+    config {
+        numkvs           = 100
+        no_store_metadata = true
+    }
+}
+
+test "kvv2_write" "kvv2_write_test" {
+    weight = 50
+    config {
+        numkvs            = 10
+        kvsize            = 1000
+        no_store_metadata = true
+    }
+}
+```

--- a/docs/tests/secret-pki-issue.md
+++ b/docs/tests/secret-pki-issue.md
@@ -669,6 +669,10 @@ See [Managed Keys](https://developer.hashicorp.com/vault/api-docs/secret/pki#man
   for certificates that are non-sensitive, or extremely short-lived. This
   option implies a value of `false` for `generate_lease`.
 
+- `no_store_metadata` `(bool: false)` - If set, metadata about certificates
+  issued against this role will not be stored in the storage backend. This can
+  improve performance when issuing large numbers of certificates.
+
 - `require_cn` `(bool: true)` - If set to false, makes the `common_name` field
   optional while generating a certificate.
 

--- a/docs/tests/secret-pki-sign.md
+++ b/docs/tests/secret-pki-sign.md
@@ -669,6 +669,10 @@ See [Managed Keys](https://developer.hashicorp.com/vault/api-docs/secret/pki#man
   for certificates that are non-sensitive, or extremely short-lived. This
   option implies a value of `false` for `generate_lease`.
 
+- `no_store_metadata` `(bool: false)` - If set, metadata about certificates
+  issued/signed against this role will not be stored in the storage backend.
+  This can improve performance when issuing large numbers of certificates.
+
 - `require_cn` `(bool: true)` - If set to false, makes the `common_name` field
   optional while generating a certificate.
 

--- a/test-fixtures/configs/kvv2.hcl
+++ b/test-fixtures/configs/kvv2.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2022, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+config {
+    numkvs           = 10
+    kvsize           = 1
+    no_store_metadata = true
+}

--- a/test-fixtures/configs/kvv2_no_store_metadata.hcl
+++ b/test-fixtures/configs/kvv2_no_store_metadata.hcl
@@ -1,0 +1,22 @@
+# Copyright IBM Corp. 2022, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+duration      = "2s"
+report_mode   = "terse"
+random_mounts = true
+
+test "kvv2_write" "kvv2_write_test" {
+    weight = 50
+    config {
+        numkvs = 10
+        no_store_metadata = true
+    }
+}
+
+test "kvv2_read" "kvv2_read_test" {
+    weight = 50
+    config {
+        numkvs = 10
+        no_store_metadata = true
+    }
+}

--- a/test-fixtures/target_secret_kvv2_test.go
+++ b/test-fixtures/target_secret_kvv2_test.go
@@ -1,0 +1,27 @@
+// Copyright IBM Corp. 2022, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dockertest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/vault-benchmark/helper/dockertest"
+	"github.com/hashicorp/vault-benchmark/helper/dockertest/dockerjobs"
+)
+
+func TestKVV2_NoStoreMetadata_Docker(t *testing.T) {
+	t.Parallel()
+
+	vaultCleanup, containerIPAddress := dockertest.CreateVaultContainer(t)
+	defer vaultCleanup()
+
+	vaultAddr := fmt.Sprintf("http://%s:8200", containerIPAddress)
+	benchmarkCleanup, exitCode := dockerjobs.CreateVaultBenchmarkContainer(t, vaultAddr, "root", "kvv2_no_store_metadata.hcl")
+	defer benchmarkCleanup()
+
+	if exitCode != 0 {
+		t.Fatalf("Unexpected error code: %v", exitCode)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `no_store_metadata` config option to KVV2 benchmark tests; when enabled, the KV secrets engine is configured with `no_store_metadata: true` at setup
- Adds `no_store_metadata` field to PKI issue and sign role configs, passed through to Vault's role configuration
- Includes unit tests and fixture configs for KVV2 `no_store_metadata`, plus updated docs for all three test types

## Test Plan

- [x] `go test ./...` passes (verified locally)
- [x] KVV2 benchmark runs correctly with `no_store_metadata = true` in config
- [x] PKI issue/sign benchmarks accept `no_store_metadata` in role config without error