### PR TITLE
Fixed parameter for tls_ca config in the mysql plugin

### DIFF
--- a/benchmarktests/target_secret_mysql.go
+++ b/benchmarktests/target_secret_mysql.go
@@ -66,7 +66,7 @@ type MySQLDBConfig struct {
 	MaxConnectionLifetime  string   `hcl:"max_connection_lifetime,optional"`
 	UsernameTemplate       string   `hcl:"username_template,optional"`
 	TLSCertificateKey      string   `hcl:"tls_certificate_key,optional"`
-	TLSCACertificate       string   `hcl:"tls_ca_certificate,optional"`
+	TLSCACertificate       string   `hcl:"tls_ca,optional"`
 	TLSServerName          string   `hcl:"tls_server_name,optional"`
 	TLSSkipVerify          bool     `hcl:"tls_skip_verify,optional"`
 }


### PR DESCRIPTION
The MySQL Database plugin uses the parameter `tls_ca`: https://developer.hashicorp.com/vault/api-docs/secret/databases/mysql-maria#tls_ca