### PR TITLE
Adding identity group read benchmark target

### DIFF
--- a/benchmarktests/target_identity_group_read.go
+++ b/benchmarktests/target_identity_group_read.go
@@ -1,0 +1,218 @@
+// Copyright IBM Corp. 2022, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmarktests
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strconv"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/vault/api"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+)
+
+const (
+	IdentityGroupReadTestType   = "identity_group_read"
+	IdentityGroupReadTestMethod = "GET"
+)
+
+func init() {
+	TestList[IdentityGroupReadTestType] = func() BenchmarkBuilder { return &IdentityGroupRead{} }
+}
+
+type IdentityGroupRead struct {
+	pathPrefix string
+	header     http.Header
+	config     *IdentityGroupReadConfig
+	groupIDs   []string
+	entityIDs  []string
+	logger     hclog.Logger
+}
+
+type IdentityGroupReadConfig struct {
+	EntityCount int `hcl:"entity_count,optional"`
+	GroupCount  int `hcl:"group_count,optional"`
+	GroupSize   int `hcl:"group_size,optional"`
+}
+
+func (i *IdentityGroupRead) ParseConfig(body hcl.Body) error {
+	testConfig := &struct {
+		Config *IdentityGroupReadConfig `hcl:"config,block"`
+	}{
+		Config: &IdentityGroupReadConfig{
+			EntityCount: 1000,
+			GroupCount:  1000,
+			GroupSize:   10,
+		},
+	}
+
+	diags := gohcl.DecodeBody(body, nil, testConfig)
+	if diags.HasErrors() {
+		return fmt.Errorf("error decoding to struct: %v", diags)
+	}
+
+	if testConfig.Config.EntityCount <= 0 {
+		return fmt.Errorf("entity_count must be greater than 0")
+	}
+	if testConfig.Config.GroupCount <= 0 {
+		return fmt.Errorf("group_count must be greater than 0")
+	}
+	if testConfig.Config.GroupSize <= 0 {
+		return fmt.Errorf("group_size must be greater than 0")
+	}
+	if testConfig.Config.GroupSize > testConfig.Config.EntityCount {
+		return fmt.Errorf("group_size (%d) cannot be greater than entity_count (%d)", testConfig.Config.GroupSize, testConfig.Config.EntityCount)
+	}
+
+	i.config = testConfig.Config
+	return nil
+}
+
+func (i *IdentityGroupRead) Setup(client *api.Client, mountName string, topLevelConfig *TopLevelTargetConfig) (BenchmarkBuilder, error) {
+	i.logger = targetLogger.Named(IdentityGroupReadTestType)
+	runID, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate run id: %v", err)
+	}
+
+	entityIDs := make([]string, 0, i.config.EntityCount)
+	groupIDs := make([]string, 0, i.config.GroupCount)
+
+	for idx := 0; idx < i.config.EntityCount; idx++ {
+		entityName := mountName + "-entity-" + runID + "-" + strconv.Itoa(idx)
+		resp, err := client.Logical().Write("identity/entity", map[string]interface{}{
+			"name": entityName,
+		})
+		if err != nil {
+			_ = i.cleanupCreatedIdentityResources(client, groupIDs, entityIDs)
+			return nil, fmt.Errorf("error creating identity entity %q: %v", entityName, err)
+		}
+
+		entityID, err := identityIDFromResponse(resp)
+		if err != nil {
+			_ = i.cleanupCreatedIdentityResources(client, groupIDs, entityIDs)
+			return nil, fmt.Errorf("error reading identity entity id for %q: %v", entityName, err)
+		}
+
+		entityIDs = append(entityIDs, entityID)
+	}
+
+	for idx := 0; idx < i.config.GroupCount; idx++ {
+		groupName := mountName + "-group-" + runID + "-" + strconv.Itoa(idx)
+		members := selectGroupMembers(entityIDs, idx, i.config.GroupSize)
+
+		resp, err := client.Logical().Write("identity/group", map[string]interface{}{
+			"name":              groupName,
+			"type":              "internal",
+			"member_entity_ids": members,
+		})
+		if err != nil {
+			_ = i.cleanupCreatedIdentityResources(client, groupIDs, entityIDs)
+			return nil, fmt.Errorf("error creating identity group %q: %v", groupName, err)
+		}
+
+		groupID, err := identityIDFromResponse(resp)
+		if err != nil {
+			_ = i.cleanupCreatedIdentityResources(client, groupIDs, entityIDs)
+			return nil, fmt.Errorf("error reading identity group id for %q: %v", groupName, err)
+		}
+
+		groupIDs = append(groupIDs, groupID)
+	}
+
+	return &IdentityGroupRead{
+		pathPrefix: "/v1/identity/group/id/",
+		header:     generateHeader(client),
+		config:     i.config,
+		groupIDs:   groupIDs,
+		entityIDs:  entityIDs,
+		logger:     i.logger,
+	}, nil
+}
+
+func (i *IdentityGroupRead) Target(client *api.Client) vegeta.Target {
+	if len(i.groupIDs) == 0 {
+		return vegeta.Target{
+			Method: IdentityGroupReadTestMethod,
+			URL:    client.Address() + "/v1/identity/group/id/",
+			Header: i.header,
+		}
+	}
+
+	groupID := i.groupIDs[rand.Intn(len(i.groupIDs))]
+	return vegeta.Target{
+		Method: IdentityGroupReadTestMethod,
+		URL:    client.Address() + "/v1/identity/group/id/" + groupID,
+		Header: i.header,
+	}
+}
+
+func (i *IdentityGroupRead) Cleanup(client *api.Client) error {
+	i.logger.Trace("cleaning up identity benchmark resources")
+	return i.cleanupCreatedIdentityResources(client, i.groupIDs, i.entityIDs)
+}
+
+func (i *IdentityGroupRead) Flags(fs *flag.FlagSet) {}
+
+func (i *IdentityGroupRead) GetTargetInfo() TargetInfo {
+	return TargetInfo{
+		method:     IdentityGroupReadTestMethod,
+		pathPrefix: i.pathPrefix,
+	}
+}
+
+func (i *IdentityGroupRead) cleanupCreatedIdentityResources(client *api.Client, groupIDs []string, entityIDs []string) error {
+	var firstErr error
+
+	for _, groupID := range groupIDs {
+		_, err := client.Logical().Delete("identity/group/id/" + groupID)
+		if err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("error deleting identity group %q: %v", groupID, err)
+		}
+	}
+
+	for _, entityID := range entityIDs {
+		_, err := client.Logical().Delete("identity/entity/id/" + entityID)
+		if err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("error deleting identity entity %q: %v", entityID, err)
+		}
+	}
+
+	return firstErr
+}
+
+func identityIDFromResponse(resp *api.Secret) (string, error) {
+	if resp == nil || resp.Data == nil {
+		return "", fmt.Errorf("empty response data")
+	}
+
+	rawID, ok := resp.Data["id"]
+	if !ok {
+		return "", fmt.Errorf("response missing id field")
+	}
+
+	id, ok := rawID.(string)
+	if !ok || id == "" {
+		return "", fmt.Errorf("response id is not a non-empty string")
+	}
+
+	return id, nil
+}
+
+func selectGroupMembers(entityIDs []string, groupIndex int, groupSize int) []string {
+	members := make([]string, 0, groupSize)
+	start := (groupIndex * groupSize) % len(entityIDs)
+
+	for offset := 0; offset < groupSize; offset++ {
+		members = append(members, entityIDs[(start+offset)%len(entityIDs)])
+	}
+
+	return members
+}

--- a/test-fixtures/configs/identity_group_read.hcl
+++ b/test-fixtures/configs/identity_group_read.hcl
@@ -1,0 +1,16 @@
+# Copyright IBM Corp. 2022, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+duration = "20s"
+report_mode = "terse"
+random_mounts = true
+cleanup = false
+
+test "identity_group_read" "identity_scale_read" {
+  weight = 100
+  config {
+    entity_count = 1000
+    group_count = 1000
+    group_size = 10
+  }
+}


### PR DESCRIPTION
This change introduces a new standard benchmark target that exercises Vault Identity at scale using the existing vault-benchmark lifecycle. This PR intentionally keeps the benchmark action simple (group reads) to validate lifecycle correctness first before adding more complex identity operations.

## What Changed
- Added a new benchmark target type: identity_group_read.
- Added target config fields for entity_count, group_count, and group_size.
- Implemented setup logic to create identity entities and internal identity groups.
- Wired generated entity IDs into generated groups via member_entity_ids.
- Added a simple benchmark action that performs read traffic against generated groups by ID.
- Added resource tracking for all created entity IDs and group IDs.
- Implemented cleanup to delete only benchmark-created resources, in required order: groups first, then entities.
- Added a sample HCL config for running the new target.

## Why
This is the first step toward benchmarking Vault Identity behavior under larger object counts. The goal is to prove that vault-benchmark can:
- create identity-scale data,
- run repeatable traffic against that generated data, and
- clean up safely without affecting unrelated resources.


## Validation
- Ran package tests for benchmark/core config/command paths.
- Verified target registration and config parsing.
- Verified setup/target/cleanup flow and cleanup ordering semantics in implementation.