### PR TITLE
Use natural sort order in benchmark reports

### DIFF
--- a/benchmarktests/reports.go
+++ b/benchmarktests/reports.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -103,14 +102,16 @@ func (r *Reporter) ReportJSON(w io.Writer) error {
 func (r *Reporter) ReportVerbose(w io.Writer) error {
 	sections := make([]string, 0, len(r.metrics))
 	for name := range r.metrics {
+		if name == "total" {
+			continue
+		}
 		sections = append(sections, name)
 	}
-	sort.Slice(sections, func(i, j int) bool {
-		if sections[i] == "total" {
-			return true
-		}
-		return sections[i] < sections[j]
-	})
+	natSort(sections)
+	// The aggregate "total" summary is most useful at the top of the report.
+	if _, ok := r.metrics["total"]; ok {
+		sections = append([]string{"total"}, sections...)
+	}
 	for _, name := range sections {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, name)
@@ -127,20 +128,18 @@ func (r *Reporter) ReportTerse(w io.Writer) error {
 	fmt.Fprintf(tw, "op\tcount\trate\tthroughput\tmean\t95th%%\t99th%%\tsuccessRatio\n")
 	const fmtstr = "%s\t%d\t%f\t%f\t%s\t%s\t%s\t%.2f%%\n"
 
-	metricNames := make([]string, 0)
+	metricNames := make([]string, 0, len(r.metrics))
 	for name := range r.metrics {
+		if name == "total" {
+			continue
+		}
 		metricNames = append(metricNames, name)
 	}
-
-	sort.Slice(metricNames, func(i, j int) bool {
-		return metricNames[i] < metricNames[j]
-	})
+	natSort(metricNames)
 
 	for _, name := range metricNames {
 		m := r.metrics[name]
-		if name != "total" {
-			fmt.Fprintf(tw, fmtstr, name, m.Requests, m.Rate, m.Throughput, m.Latencies.Mean, m.Latencies.P95, m.Latencies.P99, m.Success*100)
-		}
+		fmt.Fprintf(tw, fmtstr, name, m.Requests, m.Rate, m.Throughput, m.Latencies.Mean, m.Latencies.P95, m.Latencies.P99, m.Success*100)
 	}
 	tw.Flush()
 	return nil

--- a/benchmarktests/reports.go
+++ b/benchmarktests/reports.go
@@ -63,6 +63,10 @@ func newReporter(tm *TargetMulti, client *api.Client) *Reporter {
 	}
 	r := &Reporter{tm: tm, clientAddr: clientAddress}
 	r.metrics = make(map[string]*vegeta.Metrics, len(tm.targets)+1)
+	// TODO: "total" is a reserved key. A test named
+	// "total" would collide with this bucket and silently corrupt the aggregate
+	// (and be reported twice). Guard against it, e.g. reject the reserved name
+	// during config validation.
 	r.metrics["total"] = &vegeta.Metrics{}
 	for _, t := range tm.targets {
 		r.metrics[t.Name] = &vegeta.Metrics{}
@@ -108,15 +112,26 @@ func (r *Reporter) ReportVerbose(w io.Writer) error {
 		sections = append(sections, name)
 	}
 	natSort(sections)
-	// The aggregate "total" summary is most useful at the top of the report.
-	if _, ok := r.metrics["total"]; ok {
-		sections = append([]string{"total"}, sections...)
-	}
-	for _, name := range sections {
+
+	printSection := func(title, key string) error {
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, name)
-		if err := vegeta.NewTextReporter(r.metrics[name]).Report(w); err != nil {
+		fmt.Fprintln(w, title)
+		if err := vegeta.NewTextReporter(r.metrics[key]).Report(w); err != nil {
 			return fmt.Errorf("report error: %v", err)
+		}
+		return nil
+	}
+
+	for _, name := range sections {
+		if err := printSection(name, name); err != nil {
+			return err
+		}
+	}
+	// The aggregate across all tests is shown last, labeled so it doesn't read
+	// as just another test named "total".
+	if _, ok := r.metrics["total"]; ok {
+		if err := printSection("TOTAL", "total"); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -126,7 +141,7 @@ func (r *Reporter) ReportTerse(w io.Writer) error {
 	tw := tabwriter.NewWriter(w, 0, 8, 2, ' ', tabwriter.StripEscape)
 	fmt.Fprintf(tw, "Target: %v\n", r.clientAddr)
 	fmt.Fprintf(tw, "op\tcount\trate\tthroughput\tmean\t95th%%\t99th%%\tsuccessRatio\n")
-	const fmtstr = "%s\t%d\t%f\t%f\t%s\t%s\t%s\t%.2f%%\n"
+	const fmtstr = "%s\t%d\t%.2f\t%.2f\t%s\t%s\t%s\t%.2f%%\n"
 
 	metricNames := make([]string, 0, len(r.metrics))
 	for name := range r.metrics {
@@ -137,9 +152,19 @@ func (r *Reporter) ReportTerse(w io.Writer) error {
 	}
 	natSort(metricNames)
 
+	printRow := func(label, key string) {
+		m := r.metrics[key]
+		fmt.Fprintf(tw, fmtstr, label, m.Requests, m.Rate, m.Throughput, m.Latencies.Mean, m.Latencies.P95, m.Latencies.P99, m.Success*100)
+	}
+
 	for _, name := range metricNames {
-		m := r.metrics[name]
-		fmt.Fprintf(tw, fmtstr, name, m.Requests, m.Rate, m.Throughput, m.Latencies.Mean, m.Latencies.P95, m.Latencies.P99, m.Success*100)
+		printRow(name, name)
+	}
+	// The aggregate across all tests is shown last, separated by a rule so it
+	// doesn't read as just another op named "total".
+	if _, ok := r.metrics["total"]; ok {
+		fmt.Fprintf(tw, "---\t---\t---\t---\t---\t---\t---\t---\n")
+		printRow("TOTAL", "total")
 	}
 	tw.Flush()
 	return nil

--- a/benchmarktests/utils.go
+++ b/benchmarktests/utils.go
@@ -224,9 +224,8 @@ func IsFile(path string) (bool, error) {
 	return true, nil
 }
 
-// natLess reports whether a should sort before b using natural ordering, where
-// embedded runs of digits are compared by numeric value rather than
-// lexicographically. This makes "test2" sort before "test11".
+// natLess reports whether a should sort before b using natural ordering
+// rather than lexicographically, resulting in "test2" before "test11".
 func natLess(a, b string) bool {
 	i, j := 0, 0
 	for i < len(a) && j < len(b) {
@@ -273,8 +272,7 @@ func natLess(a, b string) bool {
 	return len(a)-i < len(b)-j
 }
 
-// natSort sorts a slice of strings in place using natural ordering (see
-// natLess).
+// natSort sorts a slice of strings in place using natural ordering
 func natSort(s []string) {
 	sort.Slice(s, func(i, j int) bool {
 		return natLess(s[i], s[j])

--- a/benchmarktests/utils.go
+++ b/benchmarktests/utils.go
@@ -19,6 +19,8 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/api"
@@ -220,4 +222,61 @@ func IsFile(path string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// natLess reports whether a should sort before b using natural ordering, where
+// embedded runs of digits are compared by numeric value rather than
+// lexicographically. This makes "test2" sort before "test11".
+func natLess(a, b string) bool {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		aDigit := a[i] >= '0' && a[i] <= '9'
+		bDigit := b[j] >= '0' && b[j] <= '9'
+
+		switch {
+		case aDigit && bDigit:
+			// Consume the full digit run from each string.
+			startA, startB := i, j
+			for i < len(a) && a[i] >= '0' && a[i] <= '9' {
+				i++
+			}
+			for j < len(b) && b[j] >= '0' && b[j] <= '9' {
+				j++
+			}
+
+			// Compare by numeric value, ignoring leading zeros.
+			numA := strings.TrimLeft(a[startA:i], "0")
+			numB := strings.TrimLeft(b[startB:j], "0")
+			if len(numA) != len(numB) {
+				return len(numA) < len(numB)
+			}
+			if numA != numB {
+				return numA < numB
+			}
+			// Equal value: fewer leading zeros sorts first for stability.
+			if (i - startA) != (j - startB) {
+				return (i - startA) < (j - startB)
+			}
+		case aDigit != bDigit:
+			// A numeric segment sorts before a non-numeric one.
+			return aDigit
+		default:
+			if a[i] != b[j] {
+				return a[i] < b[j]
+			}
+			i++
+			j++
+		}
+	}
+
+	// Whichever string has characters remaining is the longer one.
+	return len(a)-i < len(b)-j
+}
+
+// natSort sorts a slice of strings in place using natural ordering (see
+// natLess).
+func natSort(s []string) {
+	sort.Slice(s, func(i, j int) bool {
+		return natLess(s[i], s[j])
+	})
 }


### PR DESCRIPTION
## Summary

Switch benchmark report output from lexicographical ordering to natural ordering.

This improves readability for numbered benchmark names (for example:`test1`, `test2`, `test10`) without affecting benchmark execution or metrics.

## Changes

- Added `natLess` and `natSort` util helpers for natural string sorting
- Updated `ReportVerbose` and `ReportTerse` to use natural ordering
- Added `total` summary entry for `ReportTerse`
- Fixed ordering behavior around the `total` summary entry at the bottom of report
- Simplified `ReportTerse` handling of `total`

## Validation

- Ran:
  - `go build ./...`
  - `go vet ./benchmarktests/`
  - `go test ./benchmarktests/`
- Manually verified report ordering using a 100-approle-auth and kv-read config
- Verified natural ordering in both terse and verbose report modes

## Notes

This change only affects report presentation and introduces no new dependencies.