### PR TITLE
Add shared identity alias-link helper for identity_population and identity_group_read

### DIFF
--- a/benchmarktests/identity_auth_link_helper.go
+++ b/benchmarktests/identity_auth_link_helper.go
@@ -1,0 +1,145 @@
+// Copyright IBM Corp. 2022, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package benchmarktests
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/api"
+)
+
+type identityAuthLinkConfig struct {
+	CreateAliases bool
+	UserpassMount string
+	RandomMounts  bool
+}
+
+type identityAuthLinkHelper struct {
+	createAliases bool
+
+	userpassMountPath string
+	userpassAccessor  string
+
+	aliasIDs        []string
+	aliasToEntityID map[string]string
+}
+
+func newIdentityAuthLinkHelper(client *api.Client, cfg identityAuthLinkConfig) (*identityAuthLinkHelper, error) {
+	helper := &identityAuthLinkHelper{
+		createAliases:   cfg.CreateAliases,
+		aliasIDs:        make([]string, 0),
+		aliasToEntityID: make(map[string]string),
+	}
+
+	if !cfg.CreateAliases {
+		return helper, nil
+	}
+
+	authMountPath := normalizeAuthMountPath(cfg.UserpassMount)
+	if cfg.RandomMounts {
+		runID, err := uuid.GenerateUUID()
+		if err != nil {
+			return nil, fmt.Errorf("error generating userpass mount run id: %w", err)
+		}
+		authMountPath = authMountPath + "-" + runID
+	}
+
+	accessor, resolvedMountPath, err := ensureUserpassMountAccessor(client, authMountPath)
+	if err != nil {
+		return nil, err
+	}
+
+	helper.userpassAccessor = accessor
+	helper.userpassMountPath = resolvedMountPath
+
+	return helper, nil
+}
+
+func (h *identityAuthLinkHelper) createEntityAlias(client *api.Client, aliasName string, entityID string) error {
+	if !h.createAliases {
+		return nil
+	}
+
+	aliasResp, err := client.Logical().Write("identity/entity-alias", map[string]any{
+		"name":           aliasName,
+		"canonical_id":   entityID,
+		"mount_accessor": h.userpassAccessor,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating alias for entity alias name %q: %w", aliasName, err)
+	}
+
+	if aliasResp != nil && aliasResp.Data != nil {
+		if rawAliasID, ok := aliasResp.Data["id"]; ok {
+			if aliasID, ok := rawAliasID.(string); ok && aliasID != "" {
+				h.aliasIDs = append(h.aliasIDs, aliasID)
+			}
+		}
+	}
+
+	h.aliasToEntityID[aliasName] = entityID
+	return nil
+}
+
+func (h *identityAuthLinkHelper) aliasEntityLinksCopy() map[string]string {
+	links := make(map[string]string, len(h.aliasToEntityID))
+	for alias, entityID := range h.aliasToEntityID {
+		links[alias] = entityID
+	}
+
+	return links
+}
+
+func ensureUserpassMountAccessor(client *api.Client, mountPath string) (string, string, error) {
+	authMountPath := normalizeAuthMountPath(mountPath)
+	authMountKey := authMountPath + "/"
+
+	authMounts, err := client.Sys().ListAuth()
+	if err != nil {
+		return "", "", fmt.Errorf("error listing auth mounts: %w", err)
+	}
+
+	if authMount, ok := authMounts[authMountKey]; ok {
+		if authMount.Type != "userpass" {
+			return "", "", fmt.Errorf("auth mount %q exists with type %q, expected userpass", authMountPath, authMount.Type)
+		}
+
+		if authMount.Accessor == "" {
+			return "", "", fmt.Errorf("auth mount %q has empty accessor", authMountPath)
+		}
+
+		return authMount.Accessor, authMountPath, nil
+	}
+
+	if err := client.Sys().EnableAuthWithOptions(authMountPath, &api.EnableAuthOptions{Type: "userpass"}); err != nil {
+		return "", "", fmt.Errorf("error enabling userpass auth mount %q: %w", authMountPath, err)
+	}
+
+	authMounts, err = client.Sys().ListAuth()
+	if err != nil {
+		return "", "", fmt.Errorf("error listing auth mounts after enabling %q: %w", authMountPath, err)
+	}
+
+	authMount, ok := authMounts[authMountKey]
+	if !ok {
+		return "", "", fmt.Errorf("auth mount %q not found after enable", authMountPath)
+	}
+
+	if authMount.Accessor == "" {
+		return "", "", fmt.Errorf("auth mount %q has empty accessor after enable", authMountPath)
+	}
+
+	return authMount.Accessor, authMountPath, nil
+}
+
+func normalizeAuthMountPath(path string) string {
+	normalized := strings.Trim(path, "/")
+	if normalized == "" {
+		return "userpass"
+	}
+
+	return normalized
+}

--- a/benchmarktests/target_identity_group_read.go
+++ b/benchmarktests/target_identity_group_read.go
@@ -33,13 +33,16 @@ type IdentityGroupRead struct {
 	config     *IdentityGroupReadConfig
 	groupIDs   []string
 	entityIDs  []string
+	authLinker *identityAuthLinkHelper
 	logger     hclog.Logger
 }
 
 type IdentityGroupReadConfig struct {
-	EntityCount int `hcl:"entity_count,optional"`
-	GroupCount  int `hcl:"group_count,optional"`
-	GroupSize   int `hcl:"group_size,optional"`
+	EntityCount   int    `hcl:"entity_count,optional"`
+	GroupCount    int    `hcl:"group_count,optional"`
+	GroupSize     int    `hcl:"group_size,optional"`
+	CreateAliases bool   `hcl:"create_aliases,optional"`
+	UserpassMount string `hcl:"userpass_mount,optional"`
 }
 
 func (i *IdentityGroupRead) ParseConfig(body hcl.Body) error {
@@ -47,9 +50,11 @@ func (i *IdentityGroupRead) ParseConfig(body hcl.Body) error {
 		Config *IdentityGroupReadConfig `hcl:"config,block"`
 	}{
 		Config: &IdentityGroupReadConfig{
-			EntityCount: 1000,
-			GroupCount:  1000,
-			GroupSize:   10,
+			EntityCount:   1000,
+			GroupCount:    1000,
+			GroupSize:     10,
+			CreateAliases: true,
+			UserpassMount: "userpass",
 		},
 	}
 
@@ -70,6 +75,9 @@ func (i *IdentityGroupRead) ParseConfig(body hcl.Body) error {
 	if testConfig.Config.GroupSize > testConfig.Config.EntityCount {
 		return fmt.Errorf("group_size (%d) cannot be greater than entity_count (%d)", testConfig.Config.GroupSize, testConfig.Config.EntityCount)
 	}
+	if testConfig.Config.CreateAliases && testConfig.Config.UserpassMount == "" {
+		return fmt.Errorf("userpass_mount cannot be empty when create_aliases is true")
+	}
 
 	i.config = testConfig.Config
 	return nil
@@ -84,6 +92,14 @@ func (i *IdentityGroupRead) Setup(client *api.Client, mountName string, topLevel
 
 	entityIDs := make([]string, 0, i.config.EntityCount)
 	groupIDs := make([]string, 0, i.config.GroupCount)
+	authLinker, err := newIdentityAuthLinkHelper(client, identityAuthLinkConfig{
+		CreateAliases: i.config.CreateAliases,
+		UserpassMount: i.config.UserpassMount,
+		RandomMounts:  topLevelConfig != nil && topLevelConfig.RandomMounts,
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	for idx := 0; idx < i.config.EntityCount; idx++ {
 		entityName := mountName + "-entity-" + runID + "-" + strconv.Itoa(idx)
@@ -102,6 +118,12 @@ func (i *IdentityGroupRead) Setup(client *api.Client, mountName string, topLevel
 		}
 
 		entityIDs = append(entityIDs, entityID)
+
+		err = authLinker.createEntityAlias(client, entityName, entityID)
+		if err != nil {
+			_ = i.cleanupCreatedIdentityResources(client, groupIDs, entityIDs)
+			return nil, err
+		}
 	}
 
 	for idx := 0; idx < i.config.GroupCount; idx++ {
@@ -133,6 +155,7 @@ func (i *IdentityGroupRead) Setup(client *api.Client, mountName string, topLevel
 		config:     i.config,
 		groupIDs:   groupIDs,
 		entityIDs:  entityIDs,
+		authLinker: authLinker,
 		logger:     i.logger,
 	}, nil
 }
@@ -166,6 +189,15 @@ func (i *IdentityGroupRead) GetTargetInfo() TargetInfo {
 		method:     IdentityGroupReadTestMethod,
 		pathPrefix: i.pathPrefix,
 	}
+}
+
+// AliasEntityLinks returns a copy of alias name to entity ID linkages created in setup.
+func (i *IdentityGroupRead) AliasEntityLinks() map[string]string {
+	if i.authLinker == nil {
+		return map[string]string{}
+	}
+
+	return i.authLinker.aliasEntityLinksCopy()
 }
 
 func (i *IdentityGroupRead) cleanupCreatedIdentityResources(client *api.Client, groupIDs []string, entityIDs []string) error {

--- a/benchmarktests/target_identity_population.go
+++ b/benchmarktests/target_identity_population.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -35,7 +36,8 @@ type IdentityPopulation struct {
 	config     *IdentityPopulationConfig
 	logger     hclog.Logger
 
-	entityIDs []string
+	entityIDs  []string
+	authLinker *identityAuthLinkHelper
 
 	count int
 }
@@ -44,6 +46,8 @@ type IdentityPopulationConfig struct {
 	EntityCount      int    `hcl:"entity_count,optional"`
 	NamePrefix       string `hcl:"name_prefix,optional"`
 	ProgressInterval int    `hcl:"progress_interval,optional"`
+	CreateAliases    bool   `hcl:"create_aliases,optional"`
+	UserpassMount    string `hcl:"userpass_mount,optional"`
 }
 
 func (i *IdentityPopulation) ParseConfig(body hcl.Body) error {
@@ -54,6 +58,8 @@ func (i *IdentityPopulation) ParseConfig(body hcl.Body) error {
 			EntityCount:      10000,
 			NamePrefix:       "seed-entity",
 			ProgressInterval: 1000,
+			CreateAliases:    true,
+			UserpassMount:    "userpass",
 		},
 	}
 
@@ -76,19 +82,32 @@ func (i *IdentityPopulation) ParseConfig(body hcl.Body) error {
 		return fmt.Errorf("name_prefix cannot be empty")
 	}
 
+	if strings.TrimSpace(i.config.UserpassMount) == "" {
+		return fmt.Errorf("userpass_mount cannot be empty")
+	}
+
 	return nil
 }
 
 func (i *IdentityPopulation) Setup(client *api.Client, mountName string, topLevelConfig *TopLevelTargetConfig) (BenchmarkBuilder, error) {
-	// Identity is a built-in path, so this target does not create a mount.
-	// The interface requires these args for all targets.
+	// Identity is a built-in path, so this target does not create a secret mount.
+	// The interface requires this arg for all targets.
 	_ = mountName
-	_ = topLevelConfig
 
 	i.logger = targetLogger.Named(IdentityPopulationTestType)
 	i.pathPrefix = "/v1/sys/health"
 	i.header = generateHeader(client)
 	i.entityIDs = make([]string, 0, i.config.EntityCount)
+
+	authLinker, err := newIdentityAuthLinkHelper(client, identityAuthLinkConfig{
+		CreateAliases: i.config.CreateAliases,
+		UserpassMount: i.config.UserpassMount,
+		RandomMounts:  topLevelConfig != nil && topLevelConfig.RandomMounts,
+	})
+	if err != nil {
+		return nil, err
+	}
+	i.authLinker = authLinker
 
 	start := time.Now()
 	i.logger.Info("entity population start", "total", i.config.EntityCount)
@@ -123,6 +142,11 @@ func (i *IdentityPopulation) Setup(client *api.Client, mountName string, topLeve
 		}
 
 		i.entityIDs = append(i.entityIDs, id)
+
+		if err := i.authLinker.createEntityAlias(client, entityName, id); err != nil {
+			return nil, err
+		}
+
 		i.count = idx
 
 		if idx%i.config.ProgressInterval == 0 || idx == i.config.EntityCount {
@@ -138,6 +162,7 @@ func (i *IdentityPopulation) Setup(client *api.Client, mountName string, topLeve
 		config:     i.config,
 		logger:     i.logger,
 		entityIDs:  i.entityIDs,
+		authLinker: i.authLinker,
 		count:      i.count,
 	}, nil
 }
@@ -165,6 +190,15 @@ func (i *IdentityPopulation) GetTargetInfo() TargetInfo {
 }
 
 func (i *IdentityPopulation) Flags(fs *flag.FlagSet) {}
+
+// AliasEntityLinks returns a copy of alias name to entity ID linkages created in setup.
+func (i *IdentityPopulation) AliasEntityLinks() map[string]string {
+	if i.authLinker == nil {
+		return map[string]string{}
+	}
+
+	return i.authLinker.aliasEntityLinksCopy()
+}
 
 func (i *IdentityPopulation) entityName(idx int) string {
 	return fmt.Sprintf("%s-%06d", i.config.NamePrefix, idx)

--- a/docs/tests/identity-population.md
+++ b/docs/tests/identity-population.md
@@ -11,6 +11,8 @@ This target is primarily useful for seeding an identity dataset before running o
 - `entity_count` `(int: 10000)` - number of Identity entities to create during setup.
 - `name_prefix` `(string: "seed-entity")` - prefix used for generated entity names. Entity names are created as `<name_prefix>-000001`, `<name_prefix>-000002`, etc.
 - `progress_interval` `(int: 1000)` - how often to log setup progress during entity creation.
+- `create_aliases` `(bool: true)` - create one entity alias per generated entity.
+- `userpass_mount` `(string: "userpass")` - userpass auth mount used to resolve the alias mount accessor.
 
 ## Example Configuration
 
@@ -21,6 +23,8 @@ test "identity_population" "identity_population_test" {
     entity_count      = 5000
     name_prefix       = "scale-entity"
     progress_interval = 500
+    create_aliases    = true
+    userpass_mount    = "userpass"
   }
 }
 ```
@@ -29,10 +33,13 @@ test "identity_population" "identity_population_test" {
 
 - Uses Vault's built-in Identity API at `identity/entity/name/<name>`.
 - Creates entities by name in the setup phase and reads each entity back to capture its generated ID.
+- Optionally creates `identity/entity-alias` entries and links alias name to generated entity ID in-memory for later validation.
 - The attack phase uses a minimal `/v1/sys/health` GET target so the benchmark runner can execute normally.
 - Cleanup is intentionally deferred in this MVP implementation; the target does not remove created entities automatically.
 
 ## Notes
 
 - Because Identity is a Vault built-in path, this target does not create or manage a mount.
+- When `create_aliases = true`, the target will use the configured `userpass_mount` and enable it if it does not already exist.
+- This target does not perform alias-to-entity verification checks yet; it only stores linkages for later checks.
 - If you want to test pure identity-entity population without later workload, set a small duration and a low weight for this target in the overall benchmark config.

--- a/test-fixtures/configs/identity_population.hcl
+++ b/test-fixtures/configs/identity_population.hcl
@@ -6,12 +6,12 @@ report_mode = "terse"
 random_mounts = true
 cleanup = true
 
-test "identity_group_read" "identity_scale_read" {
+test "identity_population" "identity_population_aliases" {
   weight = 100
   config {
     entity_count = 1000
-    group_count = 1000
-    group_size = 10
+    name_prefix = "seed-entity"
+    progress_interval = 200
     create_aliases = true
     userpass_mount = "userpass"
   }


### PR DESCRIPTION
## Summary
This PR implements the first part of Task 2 by wiring generated identity data to auth alias metadata, without implementing login traffic or verification assertions.

## What changed
- Added a shared helper for identity auth-link setup:
  - resolves/creates userpass auth mount accessor
  - creates entity aliases using canonical entity IDs
  - stores alias -> entity linkage in memory for later validation
- Integrated the helper into:
  - identity_population target
  - identity_group_read target
- Exposed stored linkage maps via target methods for future checks.
- Added/updated config examples to show:
  - create_aliases
  - userpass_mount
  
## Validation
- Ran package tests successfully:
  - go test ./benchmarktests ./config
- Manually validated in Vault that:
  - aliases are created
  - alias lookup resolves to expected entity ID

## Notes
- With random_mounts enabled and cleanup disabled, userpass mounts accumulate across runs.
- This behavior is expected for current fixture settings.