### PR TITLE
Adding aliases and policies blocks

### DIFF
--- a/benchmarktests/identity_helper.go
+++ b/benchmarktests/identity_helper.go
@@ -128,6 +128,23 @@ func selectGroupMembers(entityIDs []string, groupIndex, groupSize int) []string 
 	return members
 }
 
+// selectPolicyNames returns polSize policy names for entityIndex using
+// wraparound so assignment is deterministic across any policy count.
+// Returns a sub-slice when the window fits without wrapping (zero copy);
+// allocates only when the window wraps past the end of policyNames.
+func selectPolicyNames(policyNames []string, entityIndex, polSize int) []string {
+	n := len(policyNames)
+	start := (entityIndex * polSize) % n
+	if start+polSize <= n {
+		return policyNames[start : start+polSize]
+	}
+	selected := make([]string, 0, polSize)
+	for offset := range polSize {
+		selected = append(selected, policyNames[(start+offset)%n])
+	}
+	return selected
+}
+
 // parseGroups resolves the group allocation into (filled, size):
 //
 //	balanced (default): ~entity_count/group_count members per group
@@ -164,6 +181,84 @@ func parseGroups(g *GroupConfig, groupCount, entityCount int) (filled, size int,
 		return groupCount, entityCount, nil
 	default:
 		return 0, 0, fmt.Errorf("invalid groups preset %q: must be \"balanced\", \"empty\", or \"full\"", g.Preset)
+	}
+}
+
+// parseAliases resolves the alias allocation into (filled, size):
+//
+//	balanced (default): ~alias_count/entity_count aliases per entity
+//	empty             : no aliases
+//	full              : alias_count aliases on every entity
+//	count+size        : count entities get size aliases, the rest empty
+func parseAliases(a *AliasesConfig, aliasCount, entityCount int) (filled, size int, err error) {
+	if aliasCount <= 0 {
+		return 0, 0, nil
+	}
+	if a == nil {
+		return entityCount, ceilDiv(aliasCount, entityCount), nil
+	}
+
+	if a.Count > 0 || a.Size > 0 {
+		if a.Preset != "" {
+			return 0, 0, fmt.Errorf("aliases: set either preset or count+size, not both")
+		}
+		if a.Count < 0 || a.Count > entityCount {
+			return 0, 0, fmt.Errorf("aliases.count (%d) must be in [0, entity_count=%d]", a.Count, entityCount)
+		}
+		if a.Size < 0 || a.Size > aliasCount {
+			return 0, 0, fmt.Errorf("aliases.size (%d) must be in [0, alias_count=%d]", a.Size, aliasCount)
+		}
+		return a.Count, a.Size, nil
+	}
+
+	switch a.Preset {
+	case "", "balanced":
+		return entityCount, ceilDiv(aliasCount, entityCount), nil
+	case "empty":
+		return 0, 0, nil
+	case "full":
+		return entityCount, aliasCount, nil
+	default:
+		return 0, 0, fmt.Errorf("invalid aliases preset %q: must be \"balanced\", \"empty\", or \"full\"", a.Preset)
+	}
+}
+
+// parsePolicies resolves the policy allocation into (filled, size):
+//
+//	balanced (default): ~policy_count/entity_count policies per entity
+//	empty             : no policies
+//	full              : policy_count policies on every entity
+//	count+size        : count entities get size policies, the rest empty
+func parsePolicies(p *PoliciesConfig, policyCount, entityCount int) (filled, size int, err error) {
+	if policyCount <= 0 {
+		return 0, 0, nil
+	}
+	if p == nil {
+		return entityCount, ceilDiv(policyCount, entityCount), nil
+	}
+
+	if p.Count > 0 || p.Size > 0 {
+		if p.Preset != "" {
+			return 0, 0, fmt.Errorf("policies: set either preset or count+size, not both")
+		}
+		if p.Count < 0 || p.Count > entityCount {
+			return 0, 0, fmt.Errorf("policies.count (%d) must be in [0, entity_count=%d]", p.Count, entityCount)
+		}
+		if p.Size < 0 || p.Size > policyCount {
+			return 0, 0, fmt.Errorf("policies.size (%d) must be in [0, policy_count=%d]", p.Size, policyCount)
+		}
+		return p.Count, p.Size, nil
+	}
+
+	switch p.Preset {
+	case "", "balanced":
+		return entityCount, ceilDiv(policyCount, entityCount), nil
+	case "empty":
+		return 0, 0, nil
+	case "full":
+		return entityCount, policyCount, nil
+	default:
+		return 0, 0, fmt.Errorf("invalid policies preset %q: must be \"balanced\", \"empty\", or \"full\"", p.Preset)
 	}
 }
 

--- a/benchmarktests/identity_helper.go
+++ b/benchmarktests/identity_helper.go
@@ -27,27 +27,43 @@ func objectName(mountName, typ, runID string, idx int) string {
 	return mountName + "-" + typ + "-" + runID + "-" + strconv.Itoa(idx)
 }
 
-// enableUserpass returns the mount accessor -- the one value later steps can't
-// derive (aliases bind to the mount by accessor, not path).
-func enableUserpass(client *api.Client, runID string) (accessor string, err error) {
-	mountPath := userpassMountPath(runID)
-	if err := client.Sys().EnableAuthWithOptions(mountPath, &api.EnableAuthOptions{Type: "userpass"}); err != nil {
-		return "", fmt.Errorf("error enabling userpass auth mount %q: %w", mountPath, err)
+// userpassSlotMountPath returns the mount path for alias slot a.
+// Slot 0 is the login mount (username == alias name); slots 1..N are bloat-only.
+func userpassSlotMountPath(runID string, slot int) string {
+	if slot == 0 {
+		return userpassMountBase + "-" + runID
+	}
+	return userpassMountBase + "-" + runID + "-" + strconv.Itoa(slot)
+}
+
+// enableUserpassMounts enables `count` userpass mounts (one per alias slot) and
+// returns their accessors in slot order.  Slot 0 is always the login mount.
+func enableUserpassMounts(client *api.Client, runID string, count int) ([]string, error) {
+	accessors := make([]string, count)
+	for slot := range count {
+		mountPath := userpassSlotMountPath(runID, slot)
+		if err := client.Sys().EnableAuthWithOptions(mountPath, &api.EnableAuthOptions{Type: "userpass"}); err != nil {
+			return nil, fmt.Errorf("error enabling userpass auth mount %q: %w", mountPath, err)
+		}
 	}
 
+	// One ListAuth call to resolve all accessors at once.
 	mounts, err := client.Sys().ListAuth()
 	if err != nil {
-		return "", fmt.Errorf("error listing auth mounts after enabling %q: %w", mountPath, err)
+		return nil, fmt.Errorf("error listing auth mounts: %w", err)
 	}
-	mount, ok := mounts[mountPath+"/"]
-	if !ok {
-		return "", fmt.Errorf("auth mount %q not found after enable", mountPath)
+	for slot := range count {
+		mountPath := userpassSlotMountPath(runID, slot)
+		mount, ok := mounts[mountPath+"/"]
+		if !ok {
+			return nil, fmt.Errorf("auth mount %q not found after enable", mountPath)
+		}
+		if mount.Accessor == "" {
+			return nil, fmt.Errorf("auth mount %q has empty accessor after enable", mountPath)
+		}
+		accessors[slot] = mount.Accessor
 	}
-	if mount.Accessor == "" {
-		return "", fmt.Errorf("auth mount %q has empty accessor after enable", mountPath)
-	}
-
-	return mount.Accessor, nil
+	return accessors, nil
 }
 
 func addEntityAlias(client *api.Client, accessor, name, entityID string) error {

--- a/benchmarktests/target_identity.go
+++ b/benchmarktests/target_identity.go
@@ -60,15 +60,16 @@ type Identity struct {
 }
 
 type IdentityConfig struct {
-	Workload    string       `hcl:"workload,optional"`
-	EntityCount int          `hcl:"entity_count,optional"`
-	AliasCount  int          `hcl:"alias_count,optional"`
-	LoginUsers  int          `hcl:"login_users,optional"`
-	GroupCount  int          `hcl:"group_count,optional"`
-	Groups      *GroupConfig `hcl:"groups,block"`
+	Workload    string          `hcl:"workload,optional"`
+	EntityCount int             `hcl:"entity_count,optional"`
+	AliasCount  int             `hcl:"alias_count,optional"`
+	LoginUsers  int             `hcl:"login_users,optional"`
+	GroupCount  int             `hcl:"group_count,optional"`
+	Groups      *GroupConfig    `hcl:"groups,block"`
+	Aliases     *AliasesConfig  `hcl:"aliases,block"`
+	PolicyCount int             `hcl:"policy_count,optional"`
+	Policies    *PoliciesConfig `hcl:"policies,block"`
 
-	// TODO: aliases -- allocation block (like groups) for >1 alias/entity across mounts.
-	// TODO: policies -- attach token_policies to entities/groups.
 	// TODO: nested groups -- member_group_ids for org-hierarchy shapes (policy resolution walks the tree).
 }
 
@@ -79,6 +80,24 @@ type GroupConfig struct {
 	Preset string `hcl:"preset,optional"` // balanced (default) | empty | full
 	Count  int    `hcl:"count,optional"`  // partial: groups that get members
 	Size   int    `hcl:"size,optional"`   // partial: members per filled group
+}
+
+// AliasesConfig controls alias distribution across entities for the alias_count budget:
+// omit or preset="balanced" spreads aliases evenly; "empty" fills nothing;
+// "full" gives every entity alias_count aliases; count+size fills only count entities.
+type AliasesConfig struct {
+	Preset string `hcl:"preset,optional"` // balanced (default) | empty | full
+	Count  int    `hcl:"count,optional"`  // partial: entities that get aliases
+	Size   int    `hcl:"size,optional"`   // partial: aliases per filled entity
+}
+
+// PoliciesConfig controls policy distribution across entities for the policy_count budget:
+// omit or preset="balanced" spreads policies evenly; "empty" fills nothing;
+// "full" attaches all policies to every entity; count+size fills only count entities.
+type PoliciesConfig struct {
+	Preset string `hcl:"preset,optional"` // balanced (default) | empty | full
+	Count  int    `hcl:"count,optional"`  // partial: entities that get policies
+	Size   int    `hcl:"size,optional"`   // partial: policies per filled entity
 }
 
 func (i *Identity) ParseConfig(body hcl.Body) error {
@@ -107,7 +126,6 @@ func (i *Identity) ParseConfig(body hcl.Body) error {
 	}
 
 	// Capped at alias_count (a user needs an alias) and entity_count (validateLogins indexes by entity).
-	// TODO: revisit this clamp once aliases block lands (alias_count may exceed entity_count by design).
 	i.loginUsers = min(c.LoginUsers, c.AliasCount, c.EntityCount)
 
 	// TODO: guard alias_count/group_count/login_users for non-negative values.
@@ -156,6 +174,14 @@ func (i *Identity) Cleanup(client *api.Client) error {
 	}
 
 	var allErrs []error
+
+	if i.config.PolicyCount > 0 {
+		if err := deleteConcurrent(i.logger, "policy deletion", client, "sys/policies/acl/", i.config.PolicyCount, func(idx int) string {
+			return objectName(i.mountName, "policy", i.runID, idx)
+		}); err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
 
 	if err := deleteConcurrent(i.logger, "group deletion", client, "identity/group/id/", len(i.groupIDs), func(idx int) string {
 		return i.groupIDs[idx]
@@ -213,7 +239,28 @@ func (i *Identity) Setup(client *api.Client, mountName string, topLevelConfig *T
 		}
 	}
 
-	entityIDs, err := result.createEntities(client, accessor)
+	var aliasFill, aliasCap int
+	if i.config.AliasCount > 0 {
+		aliasFill, aliasCap, err = parseAliases(i.config.Aliases, i.config.AliasCount, i.config.EntityCount)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var policyNames []string
+	var polFill, polSize int
+	if i.config.PolicyCount > 0 {
+		polFill, polSize, err = parsePolicies(i.config.Policies, i.config.PolicyCount, i.config.EntityCount)
+		if err != nil {
+			return nil, err
+		}
+		policyNames, err = result.createPolicies(client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	entityIDs, err := result.createEntities(client, accessor, aliasFill, aliasCap, policyNames, polFill, polSize)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +270,7 @@ func (i *Identity) Setup(client *api.Client, mountName string, topLevelConfig *T
 		if err != nil {
 			return nil, err
 		}
-		result.groupIDs, err = result.createGroups(client, entityIDs, groupFill, groupCap)
+		result.groupIDs, err = result.createGroups(client, entityIDs, groupFill, groupCap, policyNames, polFill, polSize)
 		if err != nil {
 			return nil, err
 		}
@@ -246,7 +293,7 @@ func (i *Identity) Setup(client *api.Client, mountName string, topLevelConfig *T
 
 func (i *Identity) Flags(fs *flag.FlagSet) {}
 
-func (i *Identity) createEntities(client *api.Client, accessor string) ([]string, error) {
+func (i *Identity) createEntities(client *api.Client, accessor string, aliasFill, aliasCap int, policyNames []string, polFill, polSize int) ([]string, error) {
 	total := i.config.EntityCount
 	mountPath := userpassMountPath(i.runID)
 
@@ -263,9 +310,14 @@ func (i *Identity) createEntities(client *api.Client, accessor string) ([]string
 	err := runPhase(i.logger, "entity population", total, func(idx int) error {
 		name := objectName(i.mountName, "entity", i.runID, idx)
 
-		resp, err := client.Logical().Write("identity/entity", map[string]any{
+		body := map[string]any{
 			"name": name,
-		})
+		}
+		if idx < polFill {
+			body["policies"] = selectPolicyNames(policyNames, idx, polSize)
+		}
+
+		resp, err := client.Logical().Write("identity/entity", body)
 		if err != nil {
 			return fmt.Errorf("error creating identity entity %q: %w", name, err)
 		}
@@ -279,9 +331,12 @@ func (i *Identity) createEntities(client *api.Client, accessor string) ([]string
 			entityIDs[idx] = id
 		}
 
-		if idx < i.config.AliasCount {
-			if err := addEntityAlias(client, accessor, name, id); err != nil {
-				return err
+		if idx < aliasFill {
+			for a := range aliasCap {
+				aliasName := name + "-" + strconv.Itoa(a)
+				if err := addEntityAlias(client, accessor, aliasName, id); err != nil {
+					return err
+				}
 			}
 		}
 		if idx < i.loginUsers {
@@ -290,7 +345,7 @@ func (i *Identity) createEntities(client *api.Client, accessor string) ([]string
 			}
 		}
 		return nil
-	}, "aliases", i.config.AliasCount, "login_users", i.loginUsers)
+	}, "filled", aliasFill, "aliases_per_entity", aliasCap, "login_users", i.loginUsers, "pol_filled", polFill, "policies_per_entity", polSize)
 	if err != nil {
 		return entityIDs, err
 	}
@@ -298,7 +353,29 @@ func (i *Identity) createEntities(client *api.Client, accessor string) ([]string
 	return entityIDs, nil
 }
 
-func (i *Identity) createGroups(client *api.Client, entityIDs []string, groupFill, groupCap int) ([]string, error) {
+func (i *Identity) createPolicies(client *api.Client) ([]string, error) {
+	total := i.config.PolicyCount
+	policyNames := make([]string, total)
+
+	err := runPhase(i.logger, "policy population", total, func(idx int) error {
+		name := objectName(i.mountName, "policy", i.runID, idx)
+		_, err := client.Logical().Write("sys/policies/acl/"+name, map[string]any{
+			"policy": `path "secret/*" { capabilities = ["read"] }`,
+		})
+		if err != nil {
+			return fmt.Errorf("error creating policy %q: %w", name, err)
+		}
+		policyNames[idx] = name
+		return nil
+	}, "total", total)
+	if err != nil {
+		return policyNames, err
+	}
+
+	return policyNames, nil
+}
+
+func (i *Identity) createGroups(client *api.Client, entityIDs []string, groupFill, groupCap int, policyNames []string, polFill, polSize int) ([]string, error) {
 	total := i.config.GroupCount
 	groupIDs := make([]string, total)
 
@@ -309,12 +386,17 @@ func (i *Identity) createGroups(client *api.Client, entityIDs []string, groupFil
 			members = selectGroupMembers(entityIDs, idx, groupCap)
 		}
 
-		// TODO: member_group_ids not written; no nested-group hierarchy support yet.
-		resp, err := client.Logical().Write("identity/group", map[string]any{
+		body := map[string]any{
 			"name":              groupName,
 			"type":              "internal",
 			"member_entity_ids": members,
-		})
+		}
+		if idx < polFill {
+			body["policies"] = selectPolicyNames(policyNames, idx, polSize)
+		}
+
+		// TODO: member_group_ids not written; no nested-group hierarchy support yet.
+		resp, err := client.Logical().Write("identity/group", body)
 		if err != nil {
 			return fmt.Errorf("error creating identity group %q: %w", groupName, err)
 		}

--- a/benchmarktests/target_identity.go
+++ b/benchmarktests/target_identity.go
@@ -55,6 +55,8 @@ type Identity struct {
 	loginUsers  int      // min(login_users, alias_count, entity_count)
 	loginPrefix string   // precomputed "mountName-entity-runID-"; avoids per-tick string allocs in Target
 	groupIDs    []string // live ids for group_read; removing that workload simplifies this + Cleanup
+	accessors   []string // one userpass mount accessor per alias slot (len == aliasCap)
+	aliasCap    int      // aliases per filled entity; needed by Cleanup to disable all mounts
 
 	logger hclog.Logger
 }
@@ -195,8 +197,8 @@ func (i *Identity) Cleanup(client *api.Client) error {
 		allErrs = append(allErrs, err)
 	}
 
-	if i.config.AliasCount > 0 {
-		mountPath := userpassMountPath(i.runID)
+	for slot := range i.aliasCap {
+		mountPath := userpassSlotMountPath(i.runID, slot)
 		if err := client.Sys().DisableAuth(mountPath); err != nil {
 			allErrs = append(allErrs, fmt.Errorf("error disabling userpass mount %q: %w", mountPath, err))
 		}
@@ -230,15 +232,6 @@ func (i *Identity) Setup(client *api.Client, mountName string, topLevelConfig *T
 		loginPrefix: mountName + "-entity-" + runID + "-",
 	}
 
-	// Accessor is the one value that can't be derived later; aliases bind by accessor, not path.
-	var accessor string
-	if i.config.AliasCount > 0 {
-		accessor, err = enableUserpass(client, runID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	var aliasFill, aliasCap int
 	if i.config.AliasCount > 0 {
 		aliasFill, aliasCap, err = parseAliases(i.config.Aliases, i.config.AliasCount, i.config.EntityCount)
@@ -246,6 +239,18 @@ func (i *Identity) Setup(client *api.Client, mountName string, topLevelConfig *T
 			return nil, err
 		}
 	}
+
+	// One userpass mount per alias slot so each entity can hold aliasCap aliases.
+	// Accessors are the one value that can't be derived later; aliases bind by accessor, not path.
+	var accessors []string
+	if aliasCap > 0 {
+		accessors, err = enableUserpassMounts(client, runID, aliasCap)
+		if err != nil {
+			return nil, err
+		}
+	}
+	result.accessors = accessors
+	result.aliasCap = aliasCap
 
 	var policyNames []string
 	var polFill, polSize int
@@ -260,7 +265,7 @@ func (i *Identity) Setup(client *api.Client, mountName string, topLevelConfig *T
 		}
 	}
 
-	entityIDs, err := result.createEntities(client, accessor, aliasFill, aliasCap, policyNames, polFill, polSize)
+	entityIDs, err := result.createEntities(client, accessors, aliasFill, aliasCap, policyNames, polFill, polSize)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +298,7 @@ func (i *Identity) Setup(client *api.Client, mountName string, topLevelConfig *T
 
 func (i *Identity) Flags(fs *flag.FlagSet) {}
 
-func (i *Identity) createEntities(client *api.Client, accessor string, aliasFill, aliasCap int, policyNames []string, polFill, polSize int) ([]string, error) {
+func (i *Identity) createEntities(client *api.Client, accessors []string, aliasFill, aliasCap int, policyNames []string, polFill, polSize int) ([]string, error) {
 	total := i.config.EntityCount
 	mountPath := userpassMountPath(i.runID)
 
@@ -333,8 +338,16 @@ func (i *Identity) createEntities(client *api.Client, accessor string, aliasFill
 
 		if idx < aliasFill {
 			for a := range aliasCap {
-				aliasName := name + "-" + strconv.Itoa(a)
-				if err := addEntityAlias(client, accessor, aliasName, id); err != nil {
+				// Alias 0 must match the userpass username (name) so that
+				// validateLogin and the login workload resolve to the correct entity.
+				// Additional aliases (slots 1..N) each land on their own mount
+				// accessor so Vault's one-alias-per-entity-per-accessor constraint
+				// is satisfied, and get a numeric suffix to keep names unique.
+				aliasName := name
+				if a > 0 {
+					aliasName = name + "-" + strconv.Itoa(a)
+				}
+				if err := addEntityAlias(client, accessors[a], aliasName, id); err != nil {
 					return err
 				}
 			}

--- a/benchmarktests/target_identity.go
+++ b/benchmarktests/target_identity.go
@@ -240,6 +240,13 @@ func (i *Identity) Setup(client *api.Client, mountName string, topLevelConfig *T
 		}
 	}
 
+	// If aliases resolve to no filled entities OR no aliases per entity (e.g.
+	// preset="empty", or count+size with size=0), no userpass mounts are enabled
+	// and no login users can be created or validated.
+	if aliasFill == 0 || aliasCap == 0 {
+		result.loginUsers = 0
+	}
+
 	// One userpass mount per alias slot so each entity can hold aliasCap aliases.
 	// Accessors are the one value that can't be derived later; aliases bind by accessor, not path.
 	var accessors []string
@@ -281,7 +288,7 @@ func (i *Identity) Setup(client *api.Client, mountName string, topLevelConfig *T
 		}
 	}
 
-	if i.loginUsers > 0 {
+	if result.loginUsers > 0 {
 		if err := result.validateLogins(client, entityIDs); err != nil {
 			return nil, err
 		}

--- a/docs/tests/identity.md
+++ b/docs/tests/identity.md
@@ -13,7 +13,7 @@ selected `workload` during the attack phase.
   - `login` - Log in as randomly selected users from the login pool. Requires `login_users > 0` and `alias_count > 0`.
   - `group_read` - Read randomly selected groups by id. Requires `group_count > 0`.
 - `entity_count` `(int: 1000)` - Number of Identity entities to create during setup. Primary scale axis.
-- `alias_count` `(int: 0)` - Total number of aliases to create across entities. Must be `<= entity_count` when using the default single-alias behaviour; pairs with `login_users` to make entities loginable. See also the optional `aliases` block below.
+- `alias_count` `(int: 0)` - Total number of aliases to create across entities. Pairs with `login_users` to make entities loginable. When `alias_count > entity_count`, entities receive more than one alias (e.g. `alias_count = 3000` with `entity_count = 1000` gives 3 aliases per entity under `balanced`). The benchmark provisions one userpass auth mount per alias slot, so `ceil(alias_count / entity_count)` mounts are created. See also the optional `aliases` block below.
 - `login_users` `(int: 100)` - Sample of users verified at setup (and, for the `login` workload). This checks alias resolution is correct; leave it at the default unless you have a specific reason to change it -- corruption is typically systemic, so a small sample catches it about as reliably as a large one, independent of `entity_count`.
 - `group_count` `(int: 0)` - Number of internal groups to create; `0` creates none. Pairs with an optional `groups` block (see below) that controls how members are assigned.
 - `policy_count` `(int: 0)` - Number of Vault ACL policies to create; `0` creates none. Each policy is a minimal `path "secret/*" { capabilities = ["read"] }` placeholder. Pairs with an optional `policies` block (see below) that controls which entities and groups receive them.
@@ -27,7 +27,7 @@ relevant when `alias_count > 0`. Omitting the block is equivalent to
 - `preset` `(string: "balanced")` - Named distribution strategy. One of:
   - `balanced` (default) - aliases spread evenly across all entities (`ceil(alias_count / entity_count)` per entity)
   - `empty` - no aliases are created regardless of `alias_count`
-  - `full` - every entity receives `alias_count` aliases
+  - `full` - every entity receives `alias_count` aliases. One userpass mount is provisioned per alias slot, so `alias_count` mounts are created in total.
 - `count` `(int: 0)` - Manual mode: number of entities that receive aliases. Cannot be combined with `preset`.
 - `size` `(int: 0)` - Manual mode: number of aliases each filled entity receives. Cannot be combined with `preset`.
 
@@ -171,6 +171,23 @@ test "identity" "identity_partial_policies" {
     policies {
       count = 100
       size  = 5
+    }
+  }
+}
+```
+
+Give every entity 5 aliases (one per auth mount slot), using `full`:
+
+```hcl
+test "identity" "identity_full_aliases" {
+  weight = 100
+  config {
+    workload     = "login"
+    entity_count = 1000
+    alias_count  = 5        # 5 aliases per entity; 5 userpass mounts are created
+    login_users  = 100
+    aliases {
+      preset = "full"
     }
   }
 }

--- a/docs/tests/identity.md
+++ b/docs/tests/identity.md
@@ -1,8 +1,8 @@
 # Identity Benchmark (`identity`)
 
 This benchmark seeds Vault Identity objects (entities, and optionally groups,
-aliases, and userpass users) during setup, then drives the selected `workload`
-during the attack phase.
+aliases, userpass users, and ACL policies) during setup, then drives the
+selected `workload` during the attack phase.
 
 ## Test Parameters
 
@@ -13,13 +13,50 @@ during the attack phase.
   - `login` - Log in as randomly selected users from the login pool. Requires `login_users > 0` and `alias_count > 0`.
   - `group_read` - Read randomly selected groups by id. Requires `group_count > 0`.
 - `entity_count` `(int: 1000)` - Number of Identity entities to create during setup. Primary scale axis.
-- `alias_count` `(int: 0)` - Number of entities (the first `alias_count`) that get a userpass alias. Must be `<= entity_count`; pairs with `login_users` to make entities loginable.
+- `alias_count` `(int: 0)` - Total number of aliases to create across entities. Must be `<= entity_count` when using the default single-alias behaviour; pairs with `login_users` to make entities loginable. See also the optional `aliases` block below.
 - `login_users` `(int: 100)` - Sample of users verified at setup (and, for the `login` workload). This checks alias resolution is correct; leave it at the default unless you have a specific reason to change it -- corruption is typically systemic, so a small sample catches it about as reliably as a large one, independent of `entity_count`.
-- `group_count` `(int: 0)` - Number of internal groups to create; `0` creates none. Pairs with an optional `groups` block that only matters when `group_count > 0`, controlling how members are assigned:
-  - omitted / `preset = "balanced"` (default) - members spread evenly across all groups
-  - `preset = "empty"` - groups created with no members
-  - `preset = "full"` - every group holds all entities
-  - `count = N, size = M` - only `N` groups get `M` members each, the rest are empty
+- `group_count` `(int: 0)` - Number of internal groups to create; `0` creates none. Pairs with an optional `groups` block (see below) that controls how members are assigned.
+- `policy_count` `(int: 0)` - Number of Vault ACL policies to create; `0` creates none. Each policy is a minimal `path "secret/*" { capabilities = ["read"] }` placeholder. Pairs with an optional `policies` block (see below) that controls which entities and groups receive them.
+
+### Block `aliases`
+
+Controls how the `alias_count` aliases are distributed across entities. Only
+relevant when `alias_count > 0`. Omitting the block is equivalent to
+`preset = "balanced"`.
+
+- `preset` `(string: "balanced")` - Named distribution strategy. One of:
+  - `balanced` (default) - aliases spread evenly across all entities (`ceil(alias_count / entity_count)` per entity)
+  - `empty` - no aliases are created regardless of `alias_count`
+  - `full` - every entity receives `alias_count` aliases
+- `count` `(int: 0)` - Manual mode: number of entities that receive aliases. Cannot be combined with `preset`.
+- `size` `(int: 0)` - Manual mode: number of aliases each filled entity receives. Cannot be combined with `preset`.
+
+### Block `groups`
+
+Controls how entities are assigned as members of the `group_count` groups.
+Only relevant when `group_count > 0`. Omitting the block is equivalent to
+`preset = "balanced"`.
+
+- `preset` `(string: "balanced")` - Named distribution strategy. One of:
+  - `balanced` (default) - members spread evenly across all groups (`ceil(entity_count / group_count)` per group)
+  - `empty` - groups created with no members
+  - `full` - every group holds all entities
+- `count` `(int: 0)` - Manual mode: number of groups that receive members. Cannot be combined with `preset`.
+- `size` `(int: 0)` - Manual mode: number of members per filled group. Cannot be combined with `preset`.
+
+### Block `policies`
+
+Controls how the `policy_count` policies are distributed as `token_policies`
+across entities **and** groups. Only relevant when `policy_count > 0`. Omitting
+the block is equivalent to `preset = "balanced"`. The same distribution
+parameters apply independently to both entities and groups.
+
+- `preset` `(string: "balanced")` - Named distribution strategy. One of:
+  - `balanced` (default) - policies spread evenly across all entities/groups (`ceil(policy_count / entity_count)` per object)
+  - `empty` - no policies are attached regardless of `policy_count`
+  - `full` - every entity and group receives all `policy_count` policies
+- `count` `(int: 0)` - Manual mode: number of entities/groups that receive policies. Cannot be combined with `preset`.
+- `size` `(int: 0)` - Manual mode: number of policies attached to each filled entity/group. Cannot be combined with `preset`.
 
 ## Example HCL
 
@@ -35,6 +72,41 @@ test "identity" "identity_login" {
     # verification sample; leave as-is unless you have a reason to change it.
     # (every seeded user shares password "id-pw", handy for manual debugging)
     login_users  = 100
+  }
+}
+```
+
+Give each entity multiple aliases (3 per entity), spread evenly:
+
+```hcl
+test "identity" "identity_multi_alias" {
+  weight = 100
+  config {
+    workload     = "login"
+    entity_count = 1000
+    alias_count  = 3000
+    login_users  = 100
+    aliases {
+      preset = "balanced"
+    }
+  }
+}
+```
+
+Give aliases only to a specific subset of entities -- 200 entities each get 5 aliases:
+
+```hcl
+test "identity" "identity_partial_aliases" {
+  weight = 100
+  config {
+    workload     = "login"
+    entity_count = 1000
+    alias_count  = 1000
+    login_users  = 100
+    aliases {
+      count = 200
+      size  = 5
+    }
   }
 }
 ```
@@ -70,7 +142,41 @@ test "identity" "identity_partial_groups" {
 }
 ```
 
-Seed a persistent bloat dataset:
+Attach policies to entities and groups -- 10 policies spread evenly across
+all 1000 entities, and all 50 groups each receive the balanced policy slice:
+
+```hcl
+test "identity" "identity_with_policies" {
+  weight = 100
+  config {
+    workload      = "group_read"
+    entity_count  = 1000
+    group_count   = 50
+    policy_count  = 10
+  }
+}
+```
+
+Attach a fixed number of policies to only some entities and groups -- 5 of
+the 10 policies go to 100 entities and 20 groups each:
+
+```hcl
+test "identity" "identity_partial_policies" {
+  weight = 100
+  config {
+    workload      = "group_read"
+    entity_count  = 1000
+    group_count   = 50
+    policy_count  = 10
+    policies {
+      count = 100
+      size  = 5
+    }
+  }
+}
+```
+
+Seed a persistent bloat dataset with policies attached to every object:
 
 ```hcl
 test "identity" "identity_seed" {
@@ -79,10 +185,14 @@ test "identity" "identity_seed" {
     # populate always keeps its objects, and the attack phase still runs for
     # the full global `duration` (nothing to skip to) -- keep duration short,
     # e.g. "1s".
-    workload     = "populate"
-    entity_count = 10000
-    alias_count  = 10000
+    workload      = "populate"
+    entity_count  = 10000
+    alias_count   = 10000
+    group_count   = 500
+    policy_count  = 20
+    policies {
+      preset = "full"
+    }
   }
 }
 ```
-

--- a/docs/tests/identity.md
+++ b/docs/tests/identity.md
@@ -27,7 +27,7 @@ relevant when `alias_count > 0`. Omitting the block is equivalent to
 - `preset` `(string: "balanced")` - Named distribution strategy. One of:
   - `balanced` (default) - aliases spread evenly across all entities (`ceil(alias_count / entity_count)` per entity)
   - `empty` - no aliases are created regardless of `alias_count`
-  - `full` - every entity receives `alias_count` aliases. One userpass mount is provisioned per alias slot, so `alias_count` mounts are created in total.
+  - `full` - every entity receives `alias_count` aliases each. Because `alias_count` is used directly as the aliases-per-entity cap, `alias_count` userpass mounts are created (one per slot). Note: with `full` the total aliases written is `entity_count × alias_count`, not just `alias_count`.
 - `count` `(int: 0)` - Manual mode: number of entities that receive aliases. Cannot be combined with `preset`.
 - `size` `(int: 0)` - Manual mode: number of aliases each filled entity receives. Cannot be combined with `preset`.
 
@@ -49,7 +49,9 @@ Only relevant when `group_count > 0`. Omitting the block is equivalent to
 Controls how the `policy_count` policies are distributed as `token_policies`
 across entities **and** groups. Only relevant when `policy_count > 0`. Omitting
 the block is equivalent to `preset = "balanced"`. The same distribution
-parameters apply independently to both entities and groups.
+parameters are applied to both entities and groups using a single shared
+`parsePolicies` result — `count` and `size` control both sets together, not
+each set separately.
 
 - `preset` `(string: "balanced")` - Named distribution strategy. One of:
   - `balanced` (default) - policies spread evenly across all entities/groups (`ceil(policy_count / entity_count)` per object)
@@ -202,6 +204,8 @@ test "identity" "identity_seed" {
     # populate always keeps its objects, and the attack phase still runs for
     # the full global `duration` (nothing to skip to) -- keep duration short,
     # e.g. "1s".
+    # Note: setup still runs a login-resolution validation for up to
+    # login_users (default 100) users when alias_count > 0. This is expected.
     workload      = "populate"
     entity_count  = 10000
     alias_count   = 10000

--- a/test-fixtures/configs/identity.hcl
+++ b/test-fixtures/configs/identity.hcl
@@ -31,35 +31,40 @@ test "identity" "identity_login" {
   }
 }
 
-# Login with multiple aliases per entity: 3 aliases spread evenly across
-# all entities via the aliases block.
+# Login with full alias bloating: every entity gets all 5 alias slots
+# (5 userpass mounts are created). Demonstrates the "full" preset.
 test "identity" "identity_login_multi_alias" {
   weight = 25
   config {
     workload     = "login"
     entity_count = 100
-    alias_count  = 300
+    alias_count  = 5
     login_users  = 50
     aliases {
-      preset = "balanced"
+      preset = "full"
     }
   }
 }
 
-# Read internal groups by id under load. Policies are spread evenly across
-# all entities and groups via the policies block.
+# Read groups under load. aliases preset="empty" shows that alias_count can be
+# declared but suppressed entirely. policies preset="full" attaches all 5
+# policies to every entity and group. Demonstrates "empty" and "full" presets.
 test "identity" "identity_group_read" {
   weight = 25
   config {
     workload      = "group_read"
     entity_count  = 100
+    alias_count   = 100
     group_count   = 10
     policy_count  = 5
     groups {
       preset = "balanced"
     }
+    aliases {
+      preset = "empty"
+    }
     policies {
-      preset = "balanced"
+      preset = "full"
     }
   }
 }

--- a/test-fixtures/configs/identity.hcl
+++ b/test-fixtures/configs/identity.hcl
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # General identity showcase: one run exercising every workload the target
-# supports. Kept small and short so it stays a smoke test; the docs carry the
+# supports, including the aliases and policies allocation blocks.
+# Kept small and short so it stays a smoke test; the docs carry the
 # per-workload examples.
 
 duration      = "10s"
@@ -12,7 +13,7 @@ cleanup       = true
 
 # Seed-only: builds an identity dataset, then idles on sys/health.
 test "identity" "identity_populate" {
-  weight = 34
+  weight = 25
   config {
     workload     = "populate"
     entity_count = 100
@@ -21,7 +22,7 @@ test "identity" "identity_populate" {
 
 # Log in as seeded users, validating that aliases resolve correctly.
 test "identity" "identity_login" {
-  weight = 33
+  weight = 25
   config {
     workload     = "login"
     entity_count = 100
@@ -30,15 +31,34 @@ test "identity" "identity_login" {
   }
 }
 
-# Read internal groups by id under load. An omitted groups block spreads
-# entities evenly across groups; shown here explicitly.
-test "identity" "identity_group_read" {
-  weight = 33
+# Login with multiple aliases per entity: 3 aliases spread evenly across
+# all entities via the aliases block.
+test "identity" "identity_login_multi_alias" {
+  weight = 25
   config {
-    workload     = "group_read"
+    workload     = "login"
     entity_count = 100
-    group_count  = 100
+    alias_count  = 300
+    login_users  = 50
+    aliases {
+      preset = "balanced"
+    }
+  }
+}
+
+# Read internal groups by id under load. Policies are spread evenly across
+# all entities and groups via the policies block.
+test "identity" "identity_group_read" {
+  weight = 25
+  config {
+    workload      = "group_read"
+    entity_count  = 100
+    group_count   = 10
+    policy_count  = 5
     groups {
+      preset = "balanced"
+    }
+    policies {
       preset = "balanced"
     }
   }


### PR DESCRIPTION
## Summary
Adds two new HCL allocation blocks to the identity benchmark which are aliases and policies. They follow the same pattern as the existing groups block. Both use preset modes (balanced / empty / full) or manual count + size for fine-grained control.

## What Changed
- alias_count is now a total alias budget rather than a per-entity cap. parseAliases() resolves it into (aliasFill, aliasCap); enableUserpassMounts provisions one auth mount per alias slot to satisfy Vault's one-alias-per-accessor constraint. Cleanup tears down all slot mounts.
- policy_count creates placeholder ACL policies via createPolicies(). parsePolicies() resolves distribution into (polFill, polSize) and token_policies are attached to both entities and groups using selectPolicyNames(). Cleanup deletes all created policies.
- Both blocks support the same presets as groups: balanced (even spread), empty (suppress), full (every object gets the full budget), and manual count+size.

## Validation
- go build ./benchmarktests/... passes cleanly.
- made sample hcls that test new changes, all run with out failure. 

## Notes
The policies block applies the same distribution independently to both entities and groups, a single block controls both.